### PR TITLE
Docs sweep: correct contributor guidance and three stale facts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_language.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_language.md
@@ -45,9 +45,21 @@ date_appeared: 2026-05             # YYYY-MM
 agent_tooling: [SKILL.md, AGENTS.md]
 key_idea: |
   Two to four sentences explaining the central design move.
+crossrefs:                         # optional but worth including; 2-4 is the sweet spot
+  - slug: vera                     # must match a filename in src/content/languages/
+    name: Vera
+    camp: verification
+    relation: "What is the same, and where the two part company."
+history:                           # optional; include if you can source the dates
+  - when: "May 2026"
+    what: "What happened, in one sentence."
 ---
 ```
 
-### Optional detail page
+`crossrefs` is the catalogue's main editorial device and appears on nearly every entry. See [CONTRIBUTING.md](../../CONTRIBUTING.md#frontmatter-schema) for `benchmark` and the rest.
 
-If you can write 200+ words with first-hand familiarity (the design DNA, how it compares to neighbours in the catalogue, where it strains under real use), add a Markdown body after the frontmatter. A non-empty body triggers a detail page at `/languages/<slug>/`. Card-only is the default and is fine for most submissions.
+### Detail page body
+
+Add a Markdown body after the frontmatter: 200+ words with first-hand familiarity, covering the design DNA, how it compares to neighbours in the catalogue, and where it strains under real use. A non-empty body renders a detail page at `/languages/<slug>/`, and every entry in the catalogue has one.
+
+**Code samples and pullquotes go inline in the body as raw HTML, not in frontmatter** — there is no frontmatter field for either, and anything placed there is silently dropped. Copy the `<div class="code-sample">` and `<p class="pullquote">` pattern from an existing entry; [CONTRIBUTING.md](../../CONTRIBUTING.md#detail-pages) documents the token classes and one Markdown parser quirk to avoid.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ this document useful as a map of how things fit together.
 A community-edited catalogue of programming languages designed for AI agents
 to *author* code. It is **not** a Vera marketing site (`veralang.dev`) or a
 Negroni Venture Studios product. It is a neutral directory that catalogues
-Vera alongside ~30 other languages with the same metadata format, organised
+Vera alongside three dozen other languages with the same metadata format, organised
 around three philosophical camps (Syntactic, Verification, Orchestration)
 plus Adjacent and Unclassified.
 
@@ -331,13 +331,22 @@ npm run preview  # serves the built site
 
 ## What's currently catalogued
 
-A live list is at `/llms.txt`; this section is illustrative of the
-balance across camps. As of the last refresh, the catalogue tracks
-projects across Syntactic (largest), Verification (largest and most
-mature implementations), Orchestration (smallest but most diverse),
-Adjacent (single-entry — Plumbing) and Unclassified (two entries with
-limited public evidence). Vera, MoonBit, and Boruna anchor each camp's
-detail-page treatment.
+A live list is at `/llms.txt`, and `languages.length` is the only count
+worth quoting. Do not restate a total here; it goes stale within days.
+
+The shape as of August 2026, for orientation rather than as a fact to
+cite: Verification and Syntactic are close to each other and much larger
+than the rest, Orchestration is roughly half their size but the most
+internally varied, Unclassified holds a handful of entries with limited
+public evidence, and Adjacent has just Plumbing. Verification carries the
+most mature implementations. Vera, Magpie, and Boruna anchor the three
+camps' detail-page treatments on the homepage.
+
+To get the current distribution rather than trusting this paragraph:
+
+```sh
+grep -h '^camp:' src/content/languages/*.md | sort | uniq -c | sort -rn
+```
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Academic papers without a downloadable implementation are accepted if the paper 
 ## How to submit
 
 1. Fork the repository.
-2. Add one MDX file under `src/content/languages/<slug>.md` matching the frontmatter schema below.
-3. (Optional) Write a substantive body — this triggers a detail page at `/languages/<slug>/`. Card-only is the default and is fine for most entries.
+2. Add one Markdown file under `src/content/languages/<slug>.md` matching the frontmatter schema below. The filename is the URL slug: lowercase, hyphen-separated, no spaces.
+3. Write a body. A non-empty body renders a detail page at `/languages/<slug>/`, and in practice every entry in the catalogue has one — see [Detail pages](#detail-pages) for what goes in it.
 4. Open a pull request using the new-language template.
 
 ## Frontmatter schema
@@ -44,16 +44,54 @@ agent_tooling: [SKILL.md, AGENTS.md]
 key_idea: |
   Two to four sentences explaining the central design move.
   Focus on what is distinctive, not what is shared with the camp.
+
+# Optional, and worth including. See "Optional fields" below.
+crossrefs:
+  - slug: vera                     # must match an existing filename in src/content/languages/
+    name: Vera
+    camp: verification
+    relation: "One or two sentences on what is the same and what differs."
+history:
+  - when: "May 2026"
+    what: "What happened, in one sentence."
+benchmark:
+  label: "name of the suite"
+  url: https://github.com/owner/bench
 ---
 ```
 
-**Camp classification.** Pick the closest fit and explain in the PR if the project spans camps (use `spans_camps:` for secondary camps). Marginal cases are discussed in the PR thread.
+**Camp classification.** Pick the closest fit and explain in the PR if the project spans camps (use `spans_camps:` for secondary camps). Marginal cases are discussed in the PR thread, and the maintainer makes the final call — several entries have been merged with a different secondary camp from the one submitted, with the reasoning given in the thread.
+
+**Optional fields.**
+
+- **`crossrefs`** is the one to bother with. Nearly every entry carries it, and it is the catalogue's main editorial device: two to four comparisons that say what this language shares with a neighbour and where the two part company. They render as the "design DNA" block on the detail page. Write them contrastively (`"Same diagnosis, different lever. X does A; this does B."`) rather than as a list of related projects, and check the `slug` against the filenames in `src/content/languages/`.
+- **`history`** is a dated timeline. Include it if you can source the dates; a minority of entries do.
+- **`benchmark`** is a single label and URL for a companion benchmark suite. Only include it if the project publishes numbers.
 
 **What we never ask for.** Star counts, fork counts, commit counts — these are fetched weekly by a scheduled action and committed to `src/data/stars.json`. Do not hardcode them in the language entry.
 
 ## Detail pages
 
-When a language's MDX file has a substantive body, the site renders a detail page at `/languages/<slug>/`. Use this when you can write 200+ words with first-hand familiarity — the design DNA, how the language compares to its neighbours in the catalogue, where it strains under real use. Card-only entries are the default and are not second-class; they exist when nobody has yet written that depth of analysis.
+A non-empty body renders a detail page at `/languages/<slug>/`. Every entry in the catalogue currently has one, so treat a body as expected rather than optional: 200 or more words with first-hand familiarity, covering the design DNA, how the language compares to its neighbours here, and where it strains under real use. Most entries use these section headings, in this order: `## The thesis.` (or `## What it is.`), `## What it looks like.`, `## Distinctive moves.`, `## Maturity.`, `## Agent tooling.`
+
+**Code samples and pullquotes go inline in the body, as raw HTML.** There is no frontmatter field for either, and the detail-page template renders only body content — a sample placed in frontmatter is silently dropped. Copy the pattern from an existing entry (`vera.md` and `codong.md` are good models):
+
+```html
+<p class="pullquote">A single sentence the project is willing to defend.</p>
+
+<div class="code-sample">
+  <div class="code">
+<pre><span class="kw">keyword</span> name(<span class="ty">Type</span>) {
+    <span class="ct">contract</span>(x)
+}</pre>
+  </div>
+  <p class="caption">One or two sentences on what the snippet demonstrates.</p>
+</div>
+```
+
+Token classes are `kw` (keyword), `ty` (type), `ct` (contract or attribute), `str` (string), `num` (number), `op` (operator), `sl` (slot or interpolation), `cm` (comment). Escape `<`, `>` and `&` as `&lt;`, `&gt;` and `&amp;` inside the `<pre>`.
+
+One parser quirk to avoid: **do not leave a blank line inside the `<pre>`** if the following line is indented four or more spaces. A blank line closes the surrounding HTML block, and Markdown then treats the indented remainder as a code block and escapes your `<span>` tags, so half the sample renders as visible tag text. Use a comment line in the language's own syntax for visual grouping instead.
 
 ## Tone
 
@@ -67,7 +105,15 @@ The maintainer reviews each PR for:
 - **Accuracy** — does the description match what the project does, verifiable against the repo, paper, or website?
 - **Tone** — is the one-liner neutral rather than promotional?
 
+Accuracy review means the claims in a submission get checked against the source, not taken on trust. This applies equally to entries written by the maintainer. It is not adversarial, and it cuts both ways: past reviews have corrected a figure a submitter had overstated, and also corrected one a submitter had understated to their own project's disadvantage.
+
+**Expect an editorial pass.** Most merged submissions get a commit from the maintainer either before or shortly after merge. Typical edits: adding or changing `spans_camps`, attributing project-measured benchmark numbers to the project rather than stating them flat, British-English and house-style corrections, and scoping a claim to what the code supports. The substance stays yours — thesis, structure, voice, crossref choices — and every edit is explained in the PR thread. If a pass reads wrong, say so and it gets revisited.
+
 PRs that pass merge. PRs that don't get either change requests or a polite close with an explanation. Marginal cases get discussed openly in the PR thread.
+
+## Licence for contributions
+
+Content in this repository, which includes language entries, is licensed [CC BY 4.0](LICENSE); code is [MIT](LICENSE). By opening a pull request you agree to your contribution being published under those terms. You keep the copyright in what you write.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A community-edited catalogue of programming languages designed for AI agents to author code, the site is live at [agentlanguages.dev](https://agentlanguages.dev).
 
-The site catalogues an emerging field of language design that treats LLMs and autonomous agents — not humans — as the primary authors of code. As of May 2026, the catalogue tracks projects across three philosophical camps that disagree on how to frame the underlying problem:
+The site catalogues an emerging field of language design that treats LLMs and autonomous agents — not humans — as the primary authors of code. The catalogue tracks projects across three philosophical camps that disagree on how to frame the underlying problem:
 
 - **Syntactic** — Strip ambiguity at the token level. Make syntax easier for LLMs to parse and generate.
 - **Verification** — Make contracts mechanically checkable. The model doesn't need to be right; it needs to be checkable.


### PR DESCRIPTION
A documentation sweep, prompted by noticing that `CONTRIBUTING.md` tells contributors the opposite of what the catalogue actually does. Nine items, all agreed in advance; the substantive half is contributor-facing.

## Contributor guidance (the half that was costing people something)

**Card-only entries are described as "the default".** Every entry in the catalogue has a detail page. A contributor who follows the guidance literally submits frontmatter alone and gets something structurally unlike all thirty-eight of its neighbours. The three authors who submitted this week each wrote a full body despite being told they needn't.

**Code samples and pullquotes are now documented as inline-in-body.** This is the gap that swallowed the Dice sample in #8: the schema carried `code_sample` and `pullquote` fields that the detail-page template never rendered, so a correctly-formatted submission was silently dropped. The fields are gone, but the fix only lived in `CLAUDE.md`, which is not what a contributor reads. Both docs now carry the pattern, the eight token classes, and the one Markdown quirk that breaks a `<pre>` (blank line followed by four-space-indented content, which sends the rest of the sample through the highlighter and escapes the tags).

**`crossrefs` is documented.** It appears on nearly every entry and it is the main editorial device here, yet the schema section listed neither it nor `history` nor `benchmark`. Anyone following the documented schema exactly would omit the most important optional field in the catalogue.

**Submissions now carry a warning that an editorial pass is likely,** with the typical edits named (`spans_camps`, attributing project-measured numbers, house style, scoping a claim to what the code supports) and an explicit note that the substance stays with the author. Five merged entries have had one; contributors should know it is routine rather than a rebuke. The review section also now says plainly that claims get checked against source, that this applies to my own entries too, and that it cuts both ways: one past pass corrected a figure a submitter had overstated, another corrected one they had understated against their own interest.

**The licence contributors publish under is stated** (CC BY 4.0 for content, MIT for code). People were handing over prose without being told the terms.

## Stale facts

- `README.md` said "As of May 2026".
- `CLAUDE.md` said Vera sits "alongside ~30 other languages"; it is three dozen.
- `CLAUDE.md`'s camp-balance paragraph claimed Syntactic was largest and Verification was largest, in the same sentence, and put Unclassified at two entries. Replaced with a description of the shape plus the one-line command that returns the real distribution, because any hardcoded total is stale within days. I then caught myself hardcoding "thirty-seven of thirty-eight" into the new CONTRIBUTING text and removed it.
- `CLAUDE.md` named the camp anchors as Vera, MoonBit and Boruna. They are Vera, Magpie and Boruna; MoonBit has never been one.

## Checked before pushing

Build clean at 39 pages. All eight documented token classes exist in `global.css`. `vera.md` and `codong.md`, the two entries I point contributors at, do carry both patterns. The five section headings I describe as usual appear on 25 to 30 of the 38 entries. Both relative links from the PR template resolve, both heading anchors exist, and `LICENSE` contains both the CC BY and MIT texts as described.

## Issues

Handled separately in comments rather than here: #2 needs a note that its option 1 is void (the `pullquote` frontmatter field it depends on was removed in the #8 cleanup), and #4 needs the record that an external implementation was declined and will be written fresh. #5 is still valid as filed; Tacit and Intent both still use plain fences.

