### PR TITLE
Switch the syntactic camp anchor from Magpie to NERD

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,7 @@ const findById = (id: string) => {
   return entry;
 };
 
-const magpie = findById('magpie');
+const nerd = findById('nerd');
 const vera = findById('vera');
 const boruna = findById('boruna');
 
@@ -71,8 +71,8 @@ const trackedCount = languages.length;
     campLabel="the representational camp"
     campTitle="Syntactic."
     thesis={camps.syntactic.thesis}
-    anchor={magpie}
-    anchorQuote="~2.3× more tokens per operation — and that’s the point."
+    anchor={nerd}
+    anchorQuote="The irony: cryptic symbols don’t save tokens. Plain words win."
   >
     {camps.syntactic.paragraphs.map((p) => (<p set:html={inlineMarkdownToHtml(p)}></p>))}
   </CampSection>


### PR DESCRIPTION
Magpie has been the featured entry for the syntactic camp since launch. Reviewing whether the three anchors are still the right ones, it is the one that no longer holds up.

## Why NERD

The measure that matters most for an anchor is not stars but how often the rest of the catalogue reaches for an entry as its reference point, since the anchor is the language the camp gets defined against. On that and everything else, NERD is ahead:

| | Magpie | NERD |
|---|---|---|
| Inbound crossrefs | 7 | **8** |
| Maturity | `early_implementation`, no releases | **`working_compiler`** |
| Stars | 55 | **168** |

The anchor quote improves too. Magpie's line described a cost, "~2.3× more tokens per operation, and that's the point". NERD's states the camp's empirical finding and its counter-intuitive result in ten words: "The irony: cryptic symbols don't save tokens. Plain words win." For a card whose job is to make a reader understand a camp's bet in one glance, that is the better sentence.

Magpie loses nothing else. It keeps its card in the catalogue grid and stays named in the camp prose as one of three exemplars alongside X07 and NERD, so the SSA-as-surface argument is still on the homepage. Only the featured slot moves.

## The other two stay

Vera and Boruna are the most-referenced entries in the catalogue, at 18 and 11 inbound crossrefs, well clear of any rival in their camps. Both are `working_compiler` and both have the strongest quote available in their camp.

Two rivals looked plausible on raw numbers and did not survive the closer look. Zero has thirteen times Vera's stars but is `early_implementation` with 5 inbound crossrefs. Fabro has 368 times Boruna's stars, is company-backed and would be a real candidate, but it arrived three weeks ago and nothing in the catalogue references it yet. Worth revisiting for orchestration in a couple of months if that changes.

Keeping Vera is a decision you made rather than one I made for you, given it is your project holding the featured slot in its own camp. The evidence supports it and the disclosure is on the record here.

## Verified

Built and served locally: the three anchor cards render as NERD, Vera and Boruna, with the right quotes and the right links (`/languages/nerd/`, `/languages/vera/`, `/languages/boruna/`). No console errors. Magpie still appears on the page, in the camp prose and the grid, as intended.

## Filed separately

Boruna has no code sample on its detail page, which is thin for a featured entry. That is #18 rather than part of this change.
