### PR TITLE
Credit maxinelevesque as Thermite co-creator

### DIFF
--- a/src/content/languages/thermite.md
+++ b/src/content/languages/thermite.md
@@ -6,7 +6,7 @@ one_liner: "Contract-first language with mandatory req, ens, and fx clauses; For
 url: https://github.com/dollspace-gay/Thermite
 repo: dollspace-gay/Thermite
 paper: null
-author: dollspace-gay
+author: dollspace-gay and maxinelevesque
 implementation_language: Rust and Lean 4
 compilation_target: "Rust; native Linux executables and freestanding libraries via rustc"
 license: MIT


### PR DESCRIPTION
## Correction to an existing entry

  Follow-up to #12, per the note that corrections should come as a PR against the entry.

  The `author` field in `src/content/languages/thermite.md` listed only `dollspace-gay`. Thermite is co-created by [maxinelevesque](https://github.com/maxinelevesque), so this updates the field to credit both,
  following the same multi-author format used elsewhere in the catalogue (e.g. the Zero entry).

  No other frontmatter or body changes.