### PR TITLE
chore: bump action majors, fix two GitHub Pages breaking changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,17 +13,15 @@ on:
     types: [completed]
     branches: [main]
 
-# Opt into Node 24 for all JS-based actions ahead of GitHub's June 2026
-# forced switch. Without this we run on deprecated Node 20.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 # Required for the deploy-pages action to write to the Pages environment.
 # Requires repository Settings → Pages → Source = "GitHub Actions".
+# `actions: read` is mandatory from deploy-pages v4 onwards — it reads the
+# artifact back through the Actions API, and the deploy fails without it.
 permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 # Only one deployment at a time; don't cancel a running one (so a
 # completed deploy isn't replaced mid-flight by a less-baked build).
@@ -39,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # workflow_run's default SHA is the commit that triggered the
           # *upstream* workflow, not the commit the upstream made. Pin to
@@ -47,7 +45,7 @@ jobs:
           ref: main
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -59,9 +57,13 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
+          # From v4 the action excludes dotfiles by default. We publish
+          # dist/.well-known/ai-plugin.json, so without this the agent-plugin
+          # manifest silently disappears from the deployed site.
+          include-hidden-files: true
 
   deploy:
     needs: build
@@ -72,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/refresh-stars.yml
+++ b/.github/workflows/refresh-stars.yml
@@ -7,11 +7,6 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
-# Opt into Node 24 for all JS-based actions ahead of GitHub's June 2026
-# forced switch. Without this we run on deprecated Node 20.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
 
@@ -20,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "astro": "^7.2.0"
       },
       "devDependencies": {
-        "png-to-ico": "^3.0.1"
+        "png-to-ico": "^3.0.2"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -1988,6 +1988,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/unist": {
@@ -4901,13 +4911,13 @@
       }
     },
     "node_modules/png-to-ico": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/png-to-ico/-/png-to-ico-3.0.1.tgz",
-      "integrity": "sha512-S8BOAoaGd9gT5uaemQ62arIY3Jzco7Uc7LwUTqRyqJDTsKqOAiyfyN4dSdT0D+Zf8XvgztgpRbM5wnQd7EgYwg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/png-to-ico/-/png-to-ico-3.0.2.tgz",
+      "integrity": "sha512-36vvp3/YF7LPYkUEOj08/WgB1wI63qW391YfOhOWckgOtGkarr9+EhPBimcCmRP7fJaG4EaXQhTTaQ8qqdj8aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^22.10.3",
+        "@types/node": "^25.5.0",
         "minimist": "^1.2.8",
         "pngjs": "^7.0.0"
       },
@@ -4917,23 +4927,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/png-to-ico/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/png-to-ico/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pngjs": {
       "version": "7.0.0",
@@ -5652,6 +5645,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "astro": "^7.2.0"
   },
   "devDependencies": {
-    "png-to-ico": "^3.0.1"
+    "png-to-ico": "^3.0.2"
   }
 }

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
 # Python dependencies for scripts/refresh_stars.py.
 # Installed into a local .venv/ by scripts/setup.sh; also installed into
 # the GitHub Actions runner by .github/workflows/refresh-stars.yml.
-pyyaml>=6.0
+pyyaml>=6.0.3


### PR DESCRIPTION
Seven Dependabot PRs opened on the new schedule (#30 through #36). Two of them break the site if merged as proposed, so this supersedes all seven with one reviewable change.

## The two that break

**`actions/deploy-pages` v4** [requires the `actions: read` permission](https://github.com/actions/deploy-pages/releases/tag/v4.0.0). Our block granted `contents: read`, `pages: write` and `id-token: write`, so #31 on its own would have failed the deploy job. Permission added.

**`actions/upload-pages-artifact` v4** [stopped including dotfiles in the artifact](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0). We publish `dist/.well-known/ai-plugin.json`, live at HTTP 200 today, so #33 on its own would have dropped the agent-plugin manifest from the deployed site and reported success. `include-hidden-files: true` restores it; `.well-known` is the only dotfile in `dist`, so nothing else changes shape.

That second one is the argument for landing this as one change rather than merging the queue. A broken deploy announces itself. A quietly missing machine-readable surface does not, and the manifest is one of the surfaces agents are told to look for.

## The rest

| Bump | From | To | Note |
|---|---|---|---|
| `actions/checkout` | 4 | 7 | Node 24 runtime only |
| `actions/setup-node` | 4 | 7 | Node 24 runtime only |
| `actions/setup-python` | 5 | 7 | Node 24 runtime only |
| `actions/upload-pages-artifact` | 3 | 5 | needs `include-hidden-files` |
| `actions/deploy-pages` | 4 | 5 | needs `actions: read` |
| `png-to-ico` | 3.0.1 | 3.0.2 | dev only, favicon generation |
| `pyyaml` | >=6.0 | >=6.0.3 | star-refresh script |

The three `actions/*` runtime bumps carry no other breaking change across the majors involved.

## Dropping the Node 24 opt-in

Both workflows carried `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, set ahead of GitHub's June 2026 switch off Node 20. That date has passed and every action here now declares `node24` itself, so the variable selects nothing. Removed from both files.

## Verification

- Both workflow files and `dependabot.yml` parse; the deploy permissions block resolves to four keys including `actions: read`.
- `npm run build` succeeds, 39 pages, and `dist/.well-known/ai-plugin.json` is present in the `dist` the upload step ships.
- `png-to-ico` 3.0.2 reproduces `public/favicon.ico` byte for byte. I regenerated the favicons under both 3.0.1 and 3.0.2 and compared: the `.ico` is unchanged, and the two versions produce an identical `favicon.png`.
- `pyyaml` 6.0.3 satisfies the new floor in the local venv.
- Lockfile movement is confined to `png-to-ico` and its transitive `@types/node` and `undici-types`, both types-only dev dependencies.

Deploy correctness cannot be proved from a branch, since `deploy.yml` runs on push to `main`. After merge the run needs watching, and `/.well-known/ai-plugin.json` should be re-checked for a 200.

Separately, regenerating the favicons shows `public/favicon.png` drifting from what the committed `sharp` produces, under 3.0.1 as well as 3.0.2. Pre-existing and unrelated to this bump, so it stays out of this PR.

Closes #30, #31, #32, #33, #34, #35, #36.
