### PR TITLE
fix(favicons): reproduce the committed PNG bytes, report real sizes

### DIFF
--- a/scripts/build_favicons.mjs
+++ b/scripts/build_favicons.mjs
@@ -16,6 +16,7 @@
 import sharp from 'sharp';
 import pngToIco from 'png-to-ico';
 import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { crc32 } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -29,18 +30,59 @@ const targets = [
   { name: 'icon-192.png', size: 192 },
 ];
 
+/**
+ * Pin the deflate window declared in a PNG's zlib header to 32K.
+ *
+ * libvips sizes the deflate window to the input, so images whose raw
+ * scanlines fit under 8K (favicon.png, at 4128 bytes, is the only one here)
+ * get a 8K window declared instead of 32K. The compressed payload is
+ * byte-identical either way — the window only bounds how far back a
+ * decoder may need to look, and declaring a larger one is always safe —
+ * but the two bytes of header differ, and the IDAT CRC differs with them.
+ *
+ * That made the committed PNGs drift on a libvips upgrade for no visible
+ * reason: same pixels, six different bytes. Normalising the header here
+ * keeps the output stable across sharp versions, and reproduces the
+ * originally committed bytes exactly.
+ *
+ * Only the first IDAT is touched: the zlib stream spans all IDAT chunks,
+ * so its two header bytes are always at the start of the first one.
+ */
+function pinDeflateWindow(png) {
+  const out = Buffer.from(png);
+  let i = 8; // past the 8-byte PNG signature
+  while (i < out.length) {
+    const length = out.readUInt32BE(i);
+    if (out.toString('latin1', i + 4, i + 8) === 'IDAT') {
+      const cmf = i + 8;
+      // CMF low nibble is the compression method (8 = deflate); the high
+      // nibble is log2(window) - 8, so 7 means 32K. FLG carries FLEVEL and
+      // FDICT, then five check bits chosen so the pair is a multiple of 31.
+      if ((out[cmf] & 0x0f) === 8 && out[cmf] >> 4 !== 7) {
+        out[cmf] = 0x78;
+        const flagsWithoutCheck = out[cmf + 1] & 0xe0;
+        const remainder = ((out[cmf] << 8) | flagsWithoutCheck) % 31;
+        out[cmf + 1] = flagsWithoutCheck | (remainder === 0 ? 0 : 31 - remainder);
+        out.writeUInt32BE(crc32(out.subarray(i + 4, i + 8 + length)), i + 8 + length);
+      }
+      return out;
+    }
+    i += 8 + length + 4;
+  }
+  return out;
+}
+
 const svg = await readFile(SVG);
 await mkdir(OUT_DIR, { recursive: true });
 
 // PNG variants
 for (const { name, size } of targets) {
   const out = join(OUT_DIR, name);
-  await sharp(svg)
-    .resize(size, size)
-    .png({ compressionLevel: 9 })
-    .toFile(out);
-  const stats = await sharp(out).metadata();
-  console.log(`  ✓ ${name}  ${stats.width}×${stats.height}  ${stats.size} bytes`);
+  const png = pinDeflateWindow(
+    await sharp(svg).resize(size, size).png({ compressionLevel: 9 }).toBuffer()
+  );
+  await writeFile(out, png);
+  console.log(`  ✓ ${name}  ${size}×${size}  ${png.length} bytes`);
 }
 
 // Multi-size ICO. Bundle 16, 32, and 48 into one /favicon.ico so older


### PR DESCRIPTION
Running `node scripts/build_favicons.mjs` against a clean tree left `public/favicon.png` modified. Same 312 bytes, and as it turns out the same pixels, but six different bytes.

## What was actually different

The six bytes are the two-byte zlib header at the head of the IDAT chunk, plus the four-byte CRC that covers it.

| | CMF/FLG | declared window |
|---|---|---|
| committed | `78 da` | 32768 bytes |
| regenerated | `58 c3` | 8192 bytes |

libvips sizes the deflate window to the input. `favicon.png`'s raw scanlines come to 4128 bytes, under the 8K mark, so a newer libvips began declaring an 8K window where the committed file declares 32K. The deflate payload after those two bytes is byte-identical, and so are the decoded pixels; the window is only a bound on how far back a decoder may need to look. `apple-touch-icon.png` and `icon-192.png` are large enough to sit above the threshold, which is why the smallest icon was the only one to move.

The committed image was never stale. Only its framing changed.

## The fix

`pinDeflateWindow()` sets the declared window to 32K, recomputes the five zlib check bits so the header stays a multiple of 31, and rewrites the IDAT CRC. Output no longer depends on libvips' window heuristic, and the historical bytes come back exactly.

I tried the two less invasive routes first, and neither works. No combination of sharp's `compressionLevel` and `adaptiveFiltering` reproduces the committed file (20 combinations). Re-encoding the identical raw scanlines with Node's own zlib does not either: 2835 combinations of level, strategy, `memLevel` and `windowBits`, closest being 232 bytes against the committed 234. libvips compresses this image slightly better than zlib does, so keeping its payload and correcting the header is the only route that lands on the original bytes.

## Also fixed

The PNG steps printed `undefined bytes`:

```
✓ favicon.png  32×32  undefined bytes
✓ apple-touch-icon.png  180×180  undefined bytes
```

They read `size` from `sharp().metadata()`, which is not populated when the input is a file path. They now report the buffer length, and the `.ico` step already did the right thing via `stat`.

```
✓ favicon.png  32×32  312 bytes
✓ apple-touch-icon.png  180×180  1825 bytes
✓ icon-192.png  192×192  2016 bytes
✓ favicon.ico  multi-size (16, 32, 48)  15086 bytes
```

## Verification

- All four committed files reproduce byte for byte; `git diff public/` is clean after a run.
- Running twice is idempotent.
- All three PNGs still decode as 32-bit RGBA with alpha at the right dimensions (1012 of 1024 pixels non-transparent at 32×32).
- The resulting header is `78 da`, and `((CMF << 8) | FLG) % 31 == 0` holds.

`crc32` from `node:zlib` needs Node 22.2 or newer; the README already asks for 22.12.

One limit on the scope. This pins the field that actually drifted. If a future libvips changes the compressed payload or the scanline filtering rather than the window, the bytes will move again, and re-committing the regenerated files is the right answer at that point rather than chasing it further.
