### PR TITLE
docs: correct the code-sample gotcha, both failure variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,30 +273,49 @@ passed through as raw HTML — until the parser hits a **blank line**,
 which terminates the block. Anything after the blank line is re-parsed
 as markdown.
 
-If the post-blank-line content is indented **4+ spaces** (common for
-nested-block languages — Graphviz DOT, C-family bodies, anything with a
-`{ … }` block), markdown treats it as an **indented code block**, hands
-it to Shiki, and Shiki escapes the `<` in your `<span>` tags to
-`&#x3C;`. Result: the back half of the sample renders as literal
-`<span class="ty">…</span>` text instead of highlighted tokens. (The
-escape is `&#x3C;`, not `&lt;` — so a `grep '&lt;span'` check misses it;
-grep for `class="line"` or `&#x3C;span` instead.)
+The damage comes in **two variants**, depending on how the content after
+the blank line is indented. Both are breakage; one is just louder.
 
-Two safe fixes:
+**Severe — indented 4+ spaces.** Common for nested-block languages
+(Graphviz DOT, C-family bodies, anything with a `{ … }` block). Markdown
+treats it as an **indented code block**, hands it to Shiki, and Shiki
+escapes the `<` in your `<span>` tags to `&#x3C;`. The back half of the
+sample renders as literal `<span class="ty">…</span>` text instead of
+highlighted tokens. Note the escape is `&#x3C;`, not `&lt;`, so a
+`grep '&lt;span'` check sails straight past it.
 
-1. **No blank lines inside `<pre>`.** If you want visual grouping, replace
-   the blank line with a comment line in the language's own comment syntax,
-   styled with `<span class="cm">` (e.g. `// nodes: …` in the Fabro DOT
-   sample). A comment line is not blank, so the HTML block survives.
-2. **Resume at column 0 after any blank line.** Samples whose blank lines
-   are followed by unindented content (Codong, Axis, Vow) render fine —
-   column-0 `<span>` after a blank line is parsed as inline HTML in a
-   paragraph and passes through. Only 4-space-indented resumption triggers
-   the indented-code-block path.
+**Mild — resuming at column 0.** Markdown parses the remainder as a
+paragraph, which injects `<p>` tags *inside* the `<pre>`. The tokens
+survive, so nothing looks escaped, but the sample loses its indentation
+and its line breaks go wrong. This variant emits no `class="line"` and no
+`&#x3C;`, so it passes any check that only looks for Shiki's fingerprints.
 
-Verify after editing a sample: `npm run build`, then check the `<pre>`
-in `dist/languages/<slug>/index.html` has zero `class="line"` wrappers
-(those are Shiki's, and their presence means the block broke).
+The fix, in preference order:
+
+1. **Use `<!-- -->` as the separator.** An HTML comment is not a blank
+   line to the parser, and renders as nothing inside a `<pre>`, so you get
+   the visual gap with the HTML block intact. Contributed by @rileyr on
+   the Hale entry, and better than what this file recommended before it.
+2. **A comment in the language's own syntax**, styled with `<span
+   class="cm">` (e.g. `// nodes: …` in the Fabro DOT sample). Also
+   non-blank, but it puts a visible comment in the sample.
+
+Verify after editing a sample with `npm run build`, then check the `<pre>`
+in `dist/languages/<slug>/index.html` for **all three** fingerprints —
+`class="line"` and `&#x3C;` catch the severe variant, `<p>` catches the
+mild one. To sweep the whole catalogue:
+
+```sh
+npm run build && python3 -c "
+import re, pathlib
+for f in sorted(pathlib.Path('dist/languages').glob('*/index.html')):
+    for p in re.findall(r'<pre[^>]*>.*?</pre>', f.read_text(), re.S):
+        if p.count('class=\"line\"') or '&#x3C;' in p or '<p>' in p:
+            print(f.parent.name); break
+"
+```
+
+A clean run prints nothing. Anything it lists has a broken sample.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ CC BY 4.0 for content.
 
 ## Architecture in one screen
 
-- **Framework:** Astro 6.x, static-output. No JS framework. Vanilla JS only
+- **Framework:** Astro 7.x, static-output. No JS framework. Vanilla JS only
   for the theme toggle.
 - **Content:** A single content collection at `src/content/languages/*.md`,
   schema-validated by Zod in `src/content.config.ts`. Each MDX file is one


### PR DESCRIPTION
The code-sample gotcha in CLAUDE.md documented one failure mode and gave wrong advice about the other.

## The wrong advice

"Resume at column 0 after any blank line" was listed as one of two safe fixes, with Codong, Axis and Vow cited as evidence that samples doing it render fine. They don't. Resuming at column 0 still terminates the HTML block; markdown parses the remainder as a paragraph and injects `<p>` tags inside the `<pre>`. The tokens survive, so nothing looks escaped, but the sample loses its indentation.

Built from `main`:

| entry | injected `<p>` inside `<pre>` |
|---|---|
| Codong | 1 |
| Axis | 3 |
| Vow | 2 |

## The check couldn't see it either

The documented verification was to grep the built `<pre>` for `class="line"`. That is Shiki's wrapper, and the paragraph path never reaches Shiki, so the quiet variant emits neither `class="line"` nor `&#x3C;` and passes clean. This surfaced on #21: the Hale sample was broken this way, and our own recipe would have called it fine.

## What this changes

Documents both variants and what distinguishes them, and replaces the bad fix with `<!-- -->` as the separator. That comes from @rileyr on #21 and is better than either fix this file previously recommended: an HTML comment is not blank to the parser and renders as nothing inside a `<pre>`, so the visual gap survives without a visible comment in the sample.

Also swaps the single-fingerprint check for a catalogue-wide sweep that tests all three. Verified the command runs as written and prints nothing on a clean tree.

The sweep currently lists 18 entries with broken samples, hale among them. #21 fixes hale; the remaining 17 need the same treatment, and @rileyr has offered a follow-up. No entry content is touched here.

## One unrelated fix

CLAUDE.md described the framework as "Astro 6.x". The major bump in #29 landed 7.x, so that line was stale. Corrected in the same PR since it is a one-line documentation fact in the same file.
