### PR TITLE
docs: the sample sweep matches two causes, not one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,19 @@ for f in sorted(pathlib.Path('dist/languages').glob('*/index.html')):
 "
 ```
 
-A clean run prints nothing. Anything it lists has a broken sample.
+Anything it lists renders wrongly, but for one of **two unrelated causes**,
+and the fingerprints do not distinguish them. To tell which, look at the
+entry's source:
+
+- Source has `class="code-sample"` and a blank line inside the `<pre>` —
+  the parser break described above. Fix with `<!-- -->`. Tracked in issue #40.
+- Source has a markdown fence (```` ```tacit ````, ```` ```text ````) and no
+  `class="code-sample"` — never converted to the hand-tuned pattern, so Shiki
+  handles it and there are no hand-tuned colours. Tracked in issue #5.
+
+Both routes leave Shiki's fingerprints in the output, so a hit on the sweep
+is not by itself evidence of the blank-line bug. Check the source before
+concluding which one you have.
 
 ---
 


### PR DESCRIPTION
#39 added a catalogue-wide sweep for broken code samples and claimed that anything it lists has a broken sample from the blank-line parser break. That conflates two unrelated causes.

Both routes end with the block going through Shiki, so both leave the same fingerprints in the built HTML, and the sweep cannot tell them apart:

| cause | entries | source signature | fix | tracked |
|---|---|---|---|---|
| blank line inside the `<pre>` ends the HTML block | 14 | `class="code-sample"` present | `<!-- -->` separator | #40 |
| never converted to the hand-tuned pattern | 3 (`tacit`, `intent`, `plasm`) | markdown fence, no `class="code-sample"` | hand-tune the spans | #5 |

So a hit on the sweep is not on its own evidence of the blank-line bug, and after #40 is done the sweep will keep printing those three indefinitely rather than printing nothing. Documents how to tell the two apart from the entry source and points at the right issue for each.

I got this wrong reviewing #21: I read the overlap as the contributor undercounting and told them their list of 14 was three short. Their 14 was correct. Corrected in the #21 thread as well, and #5 has been retitled to include `plasm`, which postdated it.
