### PR TITLE
Add Faber Romanus

### DIFF
--- a/src/content/languages/faber.md
+++ b/src/content/languages/faber.md
@@ -2,7 +2,7 @@
 name: Faber
 camp: syntactic
 spans_camps: []
-one_liner: "Typed compute language designed for coding agents to author and for humans to read. Mechanical, predictable syntax; reader locales so a speaker of Chinese or Thai can talk to a model and write the program in that language. Same HIR, same compile."
+one_liner: "Typed compute language designed for coding agents to author and for humans to read. Mechanical syntax; English keywords chosen by a multi-model council for the most stable, highest-probability hit on each concept; other locales render the same HIR."
 url: https://faberlang.dev
 repo: faberlang/faber
 paper: null
@@ -23,9 +23,13 @@ key_idea: |
   humans read it. The surface is mechanical and predictable — type-first
   declarations, sealed keywords, math glyphs for tensor work — so a model
   can emit it without inventing syntax. Humans are not expected to type
-  · ⊗ ⊙. HIR is the program: a reader locale is a rendering, which is why
-  someone can speak Chinese or Thai to their model, read and write the
-  .fab file in that language, and still compile the same meaning.
+  · ⊗ ⊙. Latin is the canonical lexical identity. The English locale was
+  chosen keyword-by-keyword by a council of different models for the most
+  stable, highest-probability hit on each concept, so the default public
+  surface is the one models already want to emit. HIR is the program: a
+  reader locale is a rendering, which is why someone can speak Chinese or
+  Thai to their model, read and write the .fab file in that language, and
+  still compile the same meaning.
 crossrefs:
   - slug: tacit
     name: Tacit
@@ -54,9 +58,11 @@ history:
 
 Faber is a language for coding agents to write and for humans to read. The syntax is deliberately mechanical: type-first bindings, one locale pack per file, a small glyph set for tensor work, no mixed-language spellings. A model is supposed to emit that surface without guessing. A person is supposed to read the result, not sit and type `·` and `⊗`.
 
-HIR is what makes the second half work across languages. The compiler holds one analysed program. A `.fab` file is a rendering into a reader locale — English by default, also Latin (interchange, not costume), Thai, Simplified and Traditional Chinese, Arabic, Vietnamese, Hindi. Someone who thinks in Thai can talk to their model in Thai, read the program in Thai, write the program in Thai, and it still compiles. Keywords and primitive type names change; identifiers and structural glyphs do not. Meaning does not fork.
+Latin is the canonical lexical identity — the compiler's interchange, not a costume and not the required writing language. English is the default public surface, and those keywords were not picked by taste. A council of different models chose each English keyword for the most stable, highest-probability hit on that semantic concept, so the locale agents meet first is the one they already want to emit.
 
-<p class="pullquote">Agents write it. Humans read it. The locale is theirs; the meaning is one program.</p>
+HIR is what makes the second half work across languages. The compiler holds one analysed program. A `.fab` file is a rendering into a reader locale — English by default, also Latin, Thai, Simplified and Traditional Chinese, Arabic, Vietnamese, Hindi. Someone who thinks in Thai can talk to their model in Thai, read the program in Thai, write the program in Thai, and it still compiles. Keywords and primitive type names change; identifiers and structural glyphs do not. Meaning does not fork.
+
+<p class="pullquote">Agents write it. Humans read it. English is the high-probability default; the locale is theirs; the meaning is one program.</p>
 
 The same HIR then projects onto measured compilation targets. Application lowers currently include Rust, TypeScript, Go and Swift; the MIR lane includes LLVM IR and WebAssembly; the GPU lane names Metal and CUDA. Support is stated target by target. Bounded dual-backend training on Metal and CUDA is the current proven device claim; end-to-end device GPU inference is not shipped.
 
@@ -71,7 +77,7 @@ The same HIR then projects onto measured compilation targets. Application lowers
     <span class="kw">print</span> product
 }</pre>
   </div>
-  <p class="caption">English reader surface. The same HIR renders into Thai or Chinese; a human reads their keywords, an agent emits the sealed pack, the matmul glyph and the names stay put.</p>
+  <p class="caption">English reader surface. Those keywords were chosen for model probability, not human fashion. The same HIR renders into Thai or Chinese; a human reads their keywords, an agent emits the sealed pack, the matmul glyph and the names stay put.</p>
 </div>
 
 Declarations are type-first (`const tensor&lt;f32, [2, 3]&gt; a`, not `a: Tensor`). Runtime binds use `←`. Tensor work that is a nested index walk in ordinary code is a glyph or a method: `·` matmul, `⊗` outer product, `⊙` Hadamard, `↦` convert, `.mean()` / `.sum()` for reductions. Locales are sealed: `fn` and `functio` do not mix in one file.
@@ -79,6 +85,7 @@ Declarations are type-first (`const tensor&lt;f32, [2, 3]&gt; a`, not `a: Tensor
 ## Distinctive moves.
 
 - **Agents author; humans read.** The surface is mechanical so a model can emit it. Glyphs are for the agent and the reader, not for a human to hunt on a keyboard.
+- **English keywords chosen for model probability.** Latin is canonical interchange. The English locale was set keyword-by-keyword by a council of different models for the most stable, highest-probability hit on each concept.
 - **Native-language loop through HIR.** Speak to the model in Chinese or Thai, write and read the `.fab` in that locale, compile the same program.
 - **Sealed reader packs.** One locale per file. English is the default writing surface; Latin is the interchange template, not a required writing language.
 - **Predictable tensor surface.** Rank-aware operators carry shape contracts into typechecking (inner-dimension unification on `·`, identical-shape on `⊙`).
@@ -93,4 +100,4 @@ The strain under real use is the usual early-language one, plus a specific hones
 
 ## Agent tooling.
 
-`https://faberlang.dev/llms.txt` is the machine index; `llms-full.txt` is the expanded map. The site content-negotiates an agent guide at `/en-US/` and publishes skills for install, language, packages, examples and corpus. `faber explain` answers glyphs, keywords, grammar terms and diagnostic codes. The inclusion claim is the design intent — agents as authors of a locale-rendered, mechanically predictable HIR — plus that shipped tooling, not a runtime chatbot wrapped around another language.
+`https://faberlang.dev/llms.txt` is the machine index; `llms-full.txt` is the expanded map. The site content-negotiates an agent guide at `/en-US/` and publishes skills for install, language, packages, examples and corpus. `faber explain` answers glyphs, keywords, grammar terms and diagnostic codes. The inclusion claim is the design intent — agents as authors of a locale-rendered, mechanically predictable HIR, with an English keyword surface chosen for model probability — plus that shipped tooling, not a runtime chatbot wrapped around another language.

--- a/src/content/languages/faber.md
+++ b/src/content/languages/faber.md
@@ -1,5 +1,5 @@
 ---
-name: Faber
+name: Faber Romanus
 camp: syntactic
 spans_camps: []
 one_liner: "Typed compute language designed for coding agents to author and for humans to read. Mechanical syntax; English keywords chosen by a multi-model council for the most stable, highest-probability hit on each concept; other locales render the same HIR."
@@ -19,7 +19,7 @@ agent_tooling:
   - Markdown agent guide under /en-US/
   - faber explain for glyphs, keywords, and diagnostic codes
 key_idea: |
-  Faber is built for a split audience. Coding agents write the source;
+  Faber Romanus is built for a split audience. Coding agents write the source;
   humans read it. The surface is mechanical and predictable — type-first
   declarations, sealed keywords, math glyphs for tensor work — so a model
   can emit it without inventing syntax. Humans are not expected to type
@@ -56,7 +56,7 @@ history:
 
 ## The thesis.
 
-Faber is a language for coding agents to write and for humans to read. The syntax is deliberately mechanical: type-first bindings, one locale pack per file, a small glyph set for tensor work, no mixed-language spellings. A model is supposed to emit that surface without guessing. A person is supposed to read the result, not sit and type `·` and `⊗`.
+Faber Romanus is a language for coding agents to write and for humans to read. The syntax is deliberately mechanical: type-first bindings, one locale pack per file, a small glyph set for tensor work, no mixed-language spellings. A model is supposed to emit that surface without guessing. A person is supposed to read the result, not sit and type `·` and `⊗`.
 
 Latin is the canonical lexical identity — the compiler's interchange, not a costume and not the required writing language. English is the default public surface, and those keywords were not picked by taste. A council of different models chose each English keyword for the most stable, highest-probability hit on that semantic concept, so the locale agents meet first is the one they already want to emit.
 

--- a/src/content/languages/faber.md
+++ b/src/content/languages/faber.md
@@ -1,0 +1,93 @@
+---
+name: Faber
+camp: syntactic
+spans_camps: []
+one_liner: "Typed compute language whose analysed HIR is the program. Reader locales and compilation targets are projections of that core. Designed for coding agents; tensor work uses math glyphs."
+url: https://faberlang.dev
+repo: faberlang/faber
+paper: null
+author: Ian Zepp
+implementation_language: Rust
+compilation_target: Rust, TypeScript, Go, Swift, LLVM IR, WebAssembly, Metal, CUDA
+license: MIT
+maturity: working_compiler
+date_appeared: 2025-01
+agent_tooling:
+  - llms.txt / llms-full.txt
+  - SKILL.md (install, language, examples, corpus)
+  - well-known agent-skills catalog
+  - Markdown agent guide under /en-US/
+  - faber explain for glyphs, keywords, and diagnostic codes
+key_idea: |
+  Faber treats HIR as the source of truth. What a human or agent types is a
+  rendering into a reader locale: keywords and primitive type names change,
+  identifiers and structural glyphs do not. The same analysed program then
+  lowers, target by target, toward application backends or a measured GPU
+  path. The design bet is that agents author more reliably against one
+  semantic core plus machine docs than against a single national-language
+  syntax that pretends to be the program.
+crossrefs:
+  - slug: tacit
+    name: Tacit
+    camp: syntactic
+    relation: "Same diagnosis, different lever. Tacit declares the AST authoritative and projects one canonical text; Faber declares HIR authoritative and projects many reader texts (English, Latin, Thai, Chinese, and others) plus many compilation targets. Tacit fights name-as-error with De Bruijn indices; Faber keeps names and moves the instability into locale packs."
+  - slug: x07
+    name: X07
+    camp: syntactic
+    relation: "Further along the same 'text is lossy' axis. X07 deletes the text layer and edits JSON ASTs with JSON Patch; Faber keeps text, but treats each locale file as a sealed rendering of HIR rather than as the meaning. Agents still write source; they are not asked to patch a tree."
+  - slug: zero
+    name: Zero
+    camp: verification
+    relation: "Cross-camp neighbour on agent-facing compiler output. Zero invests in structured JSON diagnostics, stable codes, and typed repair plans; Faber invests in locale-sealed source, llms.txt, and shipped skills. Zero's camp is verification; Faber's distinctive move is the HIR-and-projections split, not proof discharge."
+  - slug: vera
+    name: Vera
+    camp: verification
+    relation: "Shared agent-docs surface (llms.txt, skills), opposite thesis. Vera removes parameter names and makes every function checkable; Faber keeps a readable type-first surface and makes the same program renderable across locales. Vera assumes the model needs supervision; Faber assumes the model needs a stable meaning and a locale it can emit."
+history:
+  - when: "2025"
+    what: "Faber Romanus first appears as a typed compute language with reader-localised source and a closed compiler (Radix)."
+  - when: "Aug 2026"
+    what: "A public CLI release documents first correct end-to-end compiled inference against pinned goldens (not a shipped device-GPU inference product). Site first-contact path and experimental-through-v1 banner land."
+---
+
+## The thesis.
+
+Faber starts from the observation that coding agents already write most of the source, and that a language designed around one national syntax wastes that fact. The compiler holds one analysed program (HIR). A `.fab` file is a rendering of that program into a reader locale: English is the default writing surface, Latin is the canonical interchange dialect, and other packs (Thai, Simplified and Traditional Chinese, Arabic, Vietnamese, Hindi) exist because they stress the tokenizer and the emitter, not because the language is a novelty costume.
+
+<p class="pullquote">One semantic program. Many ways to read it.</p>
+
+The same HIR then projects onto measured compilation targets. Application lowers currently include Rust, TypeScript, Go and Swift; the MIR lane includes LLVM IR, WebAssembly and related forms; the GPU lane names Metal and CUDA. Support is stated target by target. Bounded dual-backend training on Metal and CUDA is the current proven device claim; end-to-end device GPU inference is not shipped.
+
+## What it looks like.
+
+<div class="code-sample">
+  <div class="code">
+<pre><span class="kw">main</span> {
+    <span class="kw">const</span> <span class="ty">tensor</span>&lt;<span class="ty">f32</span>, [2, 3]&gt; a ← <span class="kw">empty</span>
+    <span class="kw">const</span> <span class="ty">tensor</span>&lt;<span class="ty">f32</span>, [3, 4]&gt; b ← <span class="kw">empty</span>
+    <span class="kw">const</span> <span class="ty">tensor</span>&lt;<span class="ty">f32</span>, [2, 4]&gt; product ← a <span class="op">·</span> b
+    <span class="kw">print</span> product
+}</pre>
+  </div>
+  <p class="caption">English reader surface from the public localisation notes. Identifiers and the matmul glyph stay put when the same program is rendered into Latin, Thai, or Chinese; only keywords and primitive type names change.</p>
+</div>
+
+Declarations are type-first (`const tensor&lt;f32, [2, 3]&gt; a`, not `a: Tensor`). Runtime binds use `←`. Tensor work that is a nested index walk in ordinary code is a glyph or a method here: `·` for matmul, `⊗` for outer product, `⊙` for Hadamard, `↦` for conversion, `.mean()` / `.sum()` for reductions. Locales are sealed: `fn` and `functio` do not mix in one file.
+
+## Distinctive moves.
+
+- **HIR as the program.** Source is a locale rendering. The compiler, not the file extension, owns meaning.
+- **Sealed reader packs.** One locale per file. The English pack is where most authoring starts; Latin is the interchange template, not a required writing language.
+- **Glyph tensor surface.** Rank-aware operators carry shape contracts into typechecking (inner-dimension unification on `·`, identical-shape on `⊙`).
+- **Agent-facing docs shipped with the product.** `faberlang.dev/llms.txt`, a skills catalog, and `faber explain` for glyphs, keywords and diagnostic codes.
+- **Honest capability ladder.** Reader-localised source is shipped. Bounded Metal/CUDA training is proven. Device GPU inference and multi-device execution are not current product claims. Version 1 is experimental; stability is a version 2 claim.
+
+## Maturity.
+
+A working `faber` CLI ships as tagged release archives for macOS arm64 and Linux x86_64. The language, public libraries (including Gradus, the MIT autograd and ML library), examples and the documentation site are MIT. Radix, the compiler, is closed while it is under active development; that is presented as temporary, not as a permanent fence. Public GitHub organisation `faberlang` holds the open surface; the Haskell project at `faber-lang/faber` is unrelated.
+
+The strain under real use is the usual early-language one, plus a specific honesty gap: the tensor and inference *surface* is large (Gradus is a substantial Faber library) while device residency and GPU execution remain compiler and host concerns. A catalogue reader should not take the glyph surface as a shipped serving product.
+
+## Agent tooling.
+
+`https://faberlang.dev/llms.txt` is the machine index; `llms-full.txt` is the expanded map. The site content-negotiates an agent guide at `/en-US/` and publishes skills for install, language, packages, examples and corpus. `faber explain` answers glyphs, keywords, grammar terms and diagnostic codes. The inclusion claim is the design intent — agents as authors of a locale-rendered HIR — plus that shipped tooling, not a runtime chatbot wrapped around another language.

--- a/src/content/languages/faber.md
+++ b/src/content/languages/faber.md
@@ -2,7 +2,7 @@
 name: Faber Romanus
 camp: syntactic
 spans_camps: []
-one_liner: "Typed compute language designed for coding agents to author and for humans to read. Mechanical syntax; English keywords chosen by a multi-model council for the most stable, highest-probability hit on each concept; other locales render the same HIR."
+one_liner: "Typed compute language designed for coding agents to author and for humans to read. Mechanical syntax; the project states its English keywords were chosen by a multi-model council for the most stable, highest-probability hit on each concept; other locales render the same HIR."
 url: https://faberlang.dev
 repo: faberlang/faber
 paper: null
@@ -11,11 +11,11 @@ implementation_language: Rust
 compilation_target: Rust, TypeScript, Go, Swift, LLVM IR, WebAssembly, Metal, CUDA
 license: MIT
 maturity: working_compiler
-date_appeared: 2025-01
+date_appeared: 2026-07
 agent_tooling:
   - llms.txt / llms-full.txt
   - SKILL.md (install, language, examples, corpus)
-  - well-known agent-skills catalog
+  - well-known agent-skills catalogue
   - Markdown agent guide under /en-US/
   - faber explain for glyphs, keywords, and diagnostic codes
 key_idea: |
@@ -23,10 +23,10 @@ key_idea: |
   humans read it. The surface is mechanical and predictable — type-first
   declarations, sealed keywords, math glyphs for tensor work — so a model
   can emit it without inventing syntax. Humans are not expected to type
-  · ⊗ ⊙. Latin is the canonical lexical identity. The English locale was
-  chosen keyword-by-keyword by a council of different models for the most
-  stable, highest-probability hit on each concept, so the default public
-  surface is the one models already want to emit. HIR is the program: a
+  · ⊗ ⊙. Latin is the canonical lexical identity. The project states the
+  English locale was chosen keyword-by-keyword by a council of different
+  models for the most stable, highest-probability hit on each concept, so
+  the default public surface is the one models already want to emit. HIR is the program: a
   reader locale is a rendering, which is why someone can speak Chinese or
   Thai to their model, read and write the .fab file in that language, and
   still compile the same meaning.
@@ -48,8 +48,8 @@ crossrefs:
     camp: verification
     relation: "Both publish llms.txt and skills. Vera removes parameter names so the model cannot lean on them; Faber keeps readable names and moves the language barrier into locale packs so the model can write in the human's language."
 history:
-  - when: "2025"
-    what: "Faber Romanus first appears as a typed compute language with reader-localised source and a closed compiler (Radix)."
+  - when: "Jul 2026"
+    what: "The public <code>faber</code> CLI is imported from the closed Radix compiler and the <code>faberlang</code> organisation appears; v1.0.0 is tagged six days later."
   - when: "Aug 2026"
     what: "Public CLI documents first correct end-to-end compiled inference against pinned goldens (not a shipped device-GPU inference product). Site first-contact path and experimental-through-v1 banner land."
 ---
@@ -58,7 +58,7 @@ history:
 
 Faber Romanus is a language for coding agents to write and for humans to read. The syntax is deliberately mechanical: type-first bindings, one locale pack per file, a small glyph set for tensor work, no mixed-language spellings. A model is supposed to emit that surface without guessing. A person is supposed to read the result, not sit and type `·` and `⊗`.
 
-Latin is the canonical lexical identity — the compiler's interchange, not a costume and not the required writing language. English is the default public surface, and those keywords were not picked by taste. A council of different models chose each English keyword for the most stable, highest-probability hit on that semantic concept, so the locale agents meet first is the one they already want to emit.
+Latin is the canonical lexical identity — the compiler's interchange, not a costume and not the required writing language. English is the default public surface, and the project reports those keywords were not picked by taste: it describes a council of different models choosing each English keyword for the most stable, highest-probability hit on that semantic concept, so the locale agents meet first is the one they already want to emit.
 
 HIR is what makes the second half work across languages. The compiler holds one analysed program. A `.fab` file is a rendering into a reader locale — English by default, also Latin, Thai, Simplified and Traditional Chinese, Arabic, Vietnamese, Hindi. Someone who thinks in Thai can talk to their model in Thai, read the program in Thai, write the program in Thai, and it still compiles. Keywords and primitive type names change; identifiers and structural glyphs do not. Meaning does not fork.
 
@@ -85,16 +85,16 @@ Declarations are type-first (`const tensor&lt;f32, [2, 3]&gt; a`, not `a: Tensor
 ## Distinctive moves.
 
 - **Agents author; humans read.** The surface is mechanical so a model can emit it. Glyphs are for the agent and the reader, not for a human to hunt on a keyboard.
-- **English keywords chosen for model probability.** Latin is canonical interchange. The English locale was set keyword-by-keyword by a council of different models for the most stable, highest-probability hit on each concept.
+- **English keywords chosen for model probability.** Latin is canonical interchange. The project states the English locale was set keyword-by-keyword by a council of different models for the most stable, highest-probability hit on each concept.
 - **Native-language loop through HIR.** Speak to the model in Chinese or Thai, write and read the `.fab` in that locale, compile the same program.
 - **Sealed reader packs.** One locale per file. English is the default writing surface; Latin is the interchange template, not a required writing language.
 - **Predictable tensor surface.** Rank-aware operators carry shape contracts into typechecking (inner-dimension unification on `·`, identical-shape on `⊙`).
-- **Agent-facing docs shipped with the product.** `faberlang.dev/llms.txt`, a skills catalog, and `faber explain` for glyphs, keywords and diagnostic codes.
+- **Agent-facing docs shipped with the product.** `faberlang.dev/llms.txt`, a skills catalogue, and `faber explain` for glyphs, keywords and diagnostic codes.
 - **Honest capability ladder.** Reader-localised source is shipped. Bounded Metal/CUDA training is proven. Device GPU inference and multi-device execution are not current product claims. Version 1 is experimental; stability is a version 2 claim.
 
 ## Maturity.
 
-A working `faber` CLI ships as tagged release archives for macOS arm64 and Linux x86_64. The language, public libraries (including Gradus, the MIT autograd and ML library), examples and the documentation site are MIT. Radix, the compiler, is closed while it is under active development; that is presented as temporary, not as a permanent fence. Public GitHub organisation `faberlang` holds the open surface; the Haskell project at `faber-lang/faber` is unrelated.
+A working `faber` CLI ships as a tagged release archive; v1.0.0 publishes a macOS arm64 build. The language, public libraries (including Gradus, the MIT autograd and ML library), examples and the documentation site are MIT. Radix, the compiler, is closed while it is under active development; that is presented as temporary, not as a permanent fence. Public GitHub organisation `faberlang` holds the open surface; the Haskell project at `faber-lang/faber` is unrelated.
 
 The strain under real use is the usual early-language one, plus a specific honesty gap: the tensor and inference *surface* is large (Gradus is a substantial Faber library) while device residency and GPU execution remain compiler and host concerns. A catalogue reader should not take the glyph surface as a shipped serving product.
 

--- a/src/content/languages/faber.md
+++ b/src/content/languages/faber.md
@@ -2,7 +2,7 @@
 name: Faber
 camp: syntactic
 spans_camps: []
-one_liner: "Typed compute language whose analysed HIR is the program. Reader locales and compilation targets are projections of that core. Designed for coding agents; tensor work uses math glyphs."
+one_liner: "Typed compute language designed for coding agents to author and for humans to read. Mechanical, predictable syntax; reader locales so a speaker of Chinese or Thai can talk to a model and write the program in that language. Same HIR, same compile."
 url: https://faberlang.dev
 repo: faberlang/faber
 paper: null
@@ -19,44 +19,46 @@ agent_tooling:
   - Markdown agent guide under /en-US/
   - faber explain for glyphs, keywords, and diagnostic codes
 key_idea: |
-  Faber treats HIR as the source of truth. What a human or agent types is a
-  rendering into a reader locale: keywords and primitive type names change,
-  identifiers and structural glyphs do not. The same analysed program then
-  lowers, target by target, toward application backends or a measured GPU
-  path. The design bet is that agents author more reliably against one
-  semantic core plus machine docs than against a single national-language
-  syntax that pretends to be the program.
+  Faber is built for a split audience. Coding agents write the source;
+  humans read it. The surface is mechanical and predictable — type-first
+  declarations, sealed keywords, math glyphs for tensor work — so a model
+  can emit it without inventing syntax. Humans are not expected to type
+  · ⊗ ⊙. HIR is the program: a reader locale is a rendering, which is why
+  someone can speak Chinese or Thai to their model, read and write the
+  .fab file in that language, and still compile the same meaning.
 crossrefs:
   - slug: tacit
     name: Tacit
     camp: syntactic
-    relation: "Same diagnosis, different lever. Tacit declares the AST authoritative and projects one canonical text; Faber declares HIR authoritative and projects many reader texts (English, Latin, Thai, Chinese, and others) plus many compilation targets. Tacit fights name-as-error with De Bruijn indices; Faber keeps names and moves the instability into locale packs."
+    relation: "Tacit also treats the tree as more authoritative than one national-language spelling. Faber uses that split so a person can author with a model in their own language; Tacit uses it to canonicalise a single text and drop names toward De Bruijn indices."
   - slug: x07
     name: X07
     camp: syntactic
-    relation: "Further along the same 'text is lossy' axis. X07 deletes the text layer and edits JSON ASTs with JSON Patch; Faber keeps text, but treats each locale file as a sealed rendering of HIR rather than as the meaning. Agents still write source; they are not asked to patch a tree."
+    relation: "X07 deletes text and edits JSON ASTs. Faber keeps text on purpose: the agent still writes a .fab file, just a sealed, locale-rendered one a human can read."
   - slug: zero
     name: Zero
     camp: verification
-    relation: "Cross-camp neighbour on agent-facing compiler output. Zero invests in structured JSON diagnostics, stable codes, and typed repair plans; Faber invests in locale-sealed source, llms.txt, and shipped skills. Zero's camp is verification; Faber's distinctive move is the HIR-and-projections split, not proof discharge."
+    relation: "Both ship agent-facing compiler output (skills, structured explainers). Zero's bet is verification and typed repair; Faber's is a predictable authoring surface plus native-language reader packs."
   - slug: vera
     name: Vera
     camp: verification
-    relation: "Shared agent-docs surface (llms.txt, skills), opposite thesis. Vera removes parameter names and makes every function checkable; Faber keeps a readable type-first surface and makes the same program renderable across locales. Vera assumes the model needs supervision; Faber assumes the model needs a stable meaning and a locale it can emit."
+    relation: "Both publish llms.txt and skills. Vera removes parameter names so the model cannot lean on them; Faber keeps readable names and moves the language barrier into locale packs so the model can write in the human's language."
 history:
   - when: "2025"
     what: "Faber Romanus first appears as a typed compute language with reader-localised source and a closed compiler (Radix)."
   - when: "Aug 2026"
-    what: "A public CLI release documents first correct end-to-end compiled inference against pinned goldens (not a shipped device-GPU inference product). Site first-contact path and experimental-through-v1 banner land."
+    what: "Public CLI documents first correct end-to-end compiled inference against pinned goldens (not a shipped device-GPU inference product). Site first-contact path and experimental-through-v1 banner land."
 ---
 
 ## The thesis.
 
-Faber starts from the observation that coding agents already write most of the source, and that a language designed around one national syntax wastes that fact. The compiler holds one analysed program (HIR). A `.fab` file is a rendering of that program into a reader locale: English is the default writing surface, Latin is the canonical interchange dialect, and other packs (Thai, Simplified and Traditional Chinese, Arabic, Vietnamese, Hindi) exist because they stress the tokenizer and the emitter, not because the language is a novelty costume.
+Faber is a language for coding agents to write and for humans to read. The syntax is deliberately mechanical: type-first bindings, one locale pack per file, a small glyph set for tensor work, no mixed-language spellings. A model is supposed to emit that surface without guessing. A person is supposed to read the result, not sit and type `·` and `⊗`.
 
-<p class="pullquote">One semantic program. Many ways to read it.</p>
+HIR is what makes the second half work across languages. The compiler holds one analysed program. A `.fab` file is a rendering into a reader locale — English by default, also Latin (interchange, not costume), Thai, Simplified and Traditional Chinese, Arabic, Vietnamese, Hindi. Someone who thinks in Thai can talk to their model in Thai, read the program in Thai, write the program in Thai, and it still compiles. Keywords and primitive type names change; identifiers and structural glyphs do not. Meaning does not fork.
 
-The same HIR then projects onto measured compilation targets. Application lowers currently include Rust, TypeScript, Go and Swift; the MIR lane includes LLVM IR, WebAssembly and related forms; the GPU lane names Metal and CUDA. Support is stated target by target. Bounded dual-backend training on Metal and CUDA is the current proven device claim; end-to-end device GPU inference is not shipped.
+<p class="pullquote">Agents write it. Humans read it. The locale is theirs; the meaning is one program.</p>
+
+The same HIR then projects onto measured compilation targets. Application lowers currently include Rust, TypeScript, Go and Swift; the MIR lane includes LLVM IR and WebAssembly; the GPU lane names Metal and CUDA. Support is stated target by target. Bounded dual-backend training on Metal and CUDA is the current proven device claim; end-to-end device GPU inference is not shipped.
 
 ## What it looks like.
 
@@ -69,16 +71,17 @@ The same HIR then projects onto measured compilation targets. Application lowers
     <span class="kw">print</span> product
 }</pre>
   </div>
-  <p class="caption">English reader surface from the public localisation notes. Identifiers and the matmul glyph stay put when the same program is rendered into Latin, Thai, or Chinese; only keywords and primitive type names change.</p>
+  <p class="caption">English reader surface. The same HIR renders into Thai or Chinese; a human reads their keywords, an agent emits the sealed pack, the matmul glyph and the names stay put.</p>
 </div>
 
-Declarations are type-first (`const tensor&lt;f32, [2, 3]&gt; a`, not `a: Tensor`). Runtime binds use `←`. Tensor work that is a nested index walk in ordinary code is a glyph or a method here: `·` for matmul, `⊗` for outer product, `⊙` for Hadamard, `↦` for conversion, `.mean()` / `.sum()` for reductions. Locales are sealed: `fn` and `functio` do not mix in one file.
+Declarations are type-first (`const tensor&lt;f32, [2, 3]&gt; a`, not `a: Tensor`). Runtime binds use `←`. Tensor work that is a nested index walk in ordinary code is a glyph or a method: `·` matmul, `⊗` outer product, `⊙` Hadamard, `↦` convert, `.mean()` / `.sum()` for reductions. Locales are sealed: `fn` and `functio` do not mix in one file.
 
 ## Distinctive moves.
 
-- **HIR as the program.** Source is a locale rendering. The compiler, not the file extension, owns meaning.
-- **Sealed reader packs.** One locale per file. The English pack is where most authoring starts; Latin is the interchange template, not a required writing language.
-- **Glyph tensor surface.** Rank-aware operators carry shape contracts into typechecking (inner-dimension unification on `·`, identical-shape on `⊙`).
+- **Agents author; humans read.** The surface is mechanical so a model can emit it. Glyphs are for the agent and the reader, not for a human to hunt on a keyboard.
+- **Native-language loop through HIR.** Speak to the model in Chinese or Thai, write and read the `.fab` in that locale, compile the same program.
+- **Sealed reader packs.** One locale per file. English is the default writing surface; Latin is the interchange template, not a required writing language.
+- **Predictable tensor surface.** Rank-aware operators carry shape contracts into typechecking (inner-dimension unification on `·`, identical-shape on `⊙`).
 - **Agent-facing docs shipped with the product.** `faberlang.dev/llms.txt`, a skills catalog, and `faber explain` for glyphs, keywords and diagnostic codes.
 - **Honest capability ladder.** Reader-localised source is shipped. Bounded Metal/CUDA training is proven. Device GPU inference and multi-device execution are not current product claims. Version 1 is experimental; stability is a version 2 claim.
 
@@ -90,4 +93,4 @@ The strain under real use is the usual early-language one, plus a specific hones
 
 ## Agent tooling.
 
-`https://faberlang.dev/llms.txt` is the machine index; `llms-full.txt` is the expanded map. The site content-negotiates an agent guide at `/en-US/` and publishes skills for install, language, packages, examples and corpus. `faber explain` answers glyphs, keywords, grammar terms and diagnostic codes. The inclusion claim is the design intent — agents as authors of a locale-rendered HIR — plus that shipped tooling, not a runtime chatbot wrapped around another language.
+`https://faberlang.dev/llms.txt` is the machine index; `llms-full.txt` is the expanded map. The site content-negotiates an agent guide at `/en-US/` and publishes skills for install, language, packages, examples and corpus. `faber explain` answers glyphs, keywords, grammar terms and diagnostic codes. The inclusion claim is the design intent — agents as authors of a locale-rendered, mechanically predictable HIR — plus that shipped tooling, not a runtime chatbot wrapped around another language.


### PR DESCRIPTION
## New language submission

### Inclusion checklist

- [x] Designed for LLMs or agents to **author code** (not a runtime chatbot)
- [x] One file: `src/content/languages/faber.md`
- [x] Frontmatter against the Zod schema
- [x] One-liner descriptive, not a pitch
- [x] No star / fork / version / commit counts hardcoded
- [x] Camp justified below

### Project summary

- **Name:** Faber Romanus
- **URL:** https://faberlang.dev
- **Repo:** faberlang/faber
- **Camp:** syntactic

### Justification

Faber is designed for coding agents to write and for humans to read. The syntax is mechanical and predictable (type-first, sealed locale keywords, a small glyph set) so a model can emit it without inventing forms; humans are not expected to type the tensor glyphs.

Latin is the canonical lexical identity. The English locale — the default public surface — was chosen keyword-by-keyword by a council of different models for the most stable, highest-probability hit on each semantic concept. HIR is the program so that a speaker of Chinese or Thai can talk to their model in that language, read and write the `.fab` in that language, and still compile the same meaning. Locale text is a rendering, not the core. The site ships `llms.txt`, skills, and an agent guide.

Camp is syntactic because the distinctive move is that authoring surface (predictable tokens, LLM-chosen English keywords, sealed packs, HIR-backed locales), not SMT verification or agent orchestration. Tacit and X07 are listed as same-camp neighbours on “the tree is more stable than one spelling”; Zero and Vera as cross-camp foils on agent-facing docs. They are not the reason to include Faber.

I am the author. Happy to take an editorial pass.
