### PR TITLE
Fix code samples in 14 entries broken by a blank line

### DIFF
--- a/src/content/languages/ailang.md
+++ b/src/content/languages/ailang.md
@@ -67,9 +67,9 @@ The distinctive move is the no-loops decision. AILANG commits to lambda calculus
 <div class="code-sample">
   <div class="code">
 <pre><span class="kw">module</span> examples/hello
-
+<!-- -->
 <span class="kw">import</span> std/io (println)
-
+<!-- -->
 <span class="kw">export</span> <span class="kw">func</span> <span class="ty">main</span>() <span class="op">-&gt;</span> () ! {<span class="ct">IO</span>} {
   <span class="ty">println</span>(<span class="str">"Hello from AILANG!"</span>)
 }</pre>

--- a/src/content/languages/aver.md
+++ b/src/content/languages/aver.md
@@ -54,7 +54,7 @@ The distinctive move shows up in the comparison with Vera. The two share design 
     <span class="kw">match</span> b
         <span class="num">0</span> -&gt; <span class="ct">Result.Err</span>(<span class="str">"Division by zero"</span>)
         _ -&gt; <span class="ct">Result.Ok</span>(a / b)
-
+<!-- -->
 <span class="kw">verify</span> safeDivide
     safeDivide(<span class="num">10</span>, <span class="num">2</span>) =&gt; <span class="ct">Result.Ok</span>(<span class="num">5</span>)
     safeDivide(<span class="num">7</span>, <span class="num">0</span>)  =&gt; <span class="ct">Result.Err</span>(<span class="str">"Division by zero"</span>)</pre>

--- a/src/content/languages/axis.md
+++ b/src/content/languages/axis.md
@@ -62,15 +62,15 @@ The distinctive move is constrained decoding shipped as toolchain output. `axis 
   id <span class="ty">UUID</span> <span class="ct">PK</span> <span class="ct">AUTO</span>
   title <span class="ty">STRING</span> <span class="num">200</span> <span class="ct">REQUIRED</span>
   completed <span class="ty">BOOL</span> <span class="ct">DEFAULT</span> <span class="kw">false</span>
-
+<!-- -->
 <span class="kw">SOURCE</span> todos <span class="kw">POSTGRES</span>
   <span class="kw">SHAPE</span> <span class="ty">Todo</span>
   <span class="ct">INDEX</span> completed
-
+<!-- -->
 <span class="kw">REALM</span> api
   <span class="ct">CAPABILITY</span> read todos
   <span class="ct">CAPABILITY</span> write todos
-
+<!-- -->
 <span class="kw">FLOW</span> get_todo <span class="kw">get</span> /todos/:id
   <span class="kw">REALM</span> api
   <span class="kw">LET</span> todo

--- a/src/content/languages/codong.md
+++ b/src/content/languages/codong.md
@@ -61,7 +61,7 @@ The distinctive move is which kind of choice gets eliminated. NERD strips operat
     port = config.get(<span class="str">"port"</span>, <span class="num">8080</span>)
     <span class="kw">return</span> {host: host, port: port}
 }
-
+<!-- -->
 <span class="kw">try</span> {
     config = load_config(<span class="str">"config.json"</span>)<span class="op">?</span>
     print(<span class="str">"Server: <span class="sl">{config.host}</span>:<span class="sl">{config.port}</span>"</span>)

--- a/src/content/languages/llmlang.md
+++ b/src/content/languages/llmlang.md
@@ -63,7 +63,7 @@ The distinctive move sits in two places at once. The first is the density lever:
   <div class="code">
 <pre><span class="cm">// Factorial. ^0 refers to the most-recent binding (the parameter n).</span>
 <span class="kw">:</span> fact n <span class="op">?</span> <span class="sl">^0</span> <span class="op">*</span> <span class="op">$</span> <span class="sl">^0</span> <span class="kw">@</span> fact <span class="op">-</span> <span class="op">></span> <span class="sl">^0</span> <span class="num">1</span> <span class="op">></span> <span class="sl">^0</span>
-
+<!-- -->
 <span class="cm">// Auto-instrumented function. The M marker triggers compiler-injected</span>
 <span class="cm">// span entry/exit and timing around handle_request.</span>
 <span class="kw">M</span> <span class="str">"otel"</span> <span class="str">"handle_request"</span> <span class="kw">:</span> handle_request req

--- a/src/content/languages/lume.md
+++ b/src/content/languages/lume.md
@@ -62,13 +62,13 @@ The distinctive move sits in the toolchain rather than the syntax. `lume kb pack
     id: <span class="ty">str</span>
     balance: <span class="ty">int</span>
 }
-
+<!-- -->
 <span class="kw">fn</span> debit(acc: <span class="ty">Account</span>, amount: <span class="ty">int</span>) -&gt; <span class="ty">Account</span>
 <span class="str">"Returns a new Account with balance reduced by amount."</span>
 {
     acc.with(balance<span class="op">=</span> acc.balance <span class="op">-</span> amount)
 }
-
+<!-- -->
 <span class="kw">fn</span> main()
 {
     acc <span class="op">=</span> <span class="ty">Account</span>(id<span class="op">=</span> <span class="str">"acc-1"</span>, balance<span class="op">=</span> <span class="num">1000</span>)

--- a/src/content/languages/lumen.md
+++ b/src/content/languages/lumen.md
@@ -61,12 +61,12 @@ The distinctive move is making the source file the same artefact as the document
 <pre><span class="kw">effect</span> <span class="ty">Log</span>
   <span class="kw">cell</span> info(msg: <span class="ty">String</span>) -&gt; <span class="ty">Unit</span>
 <span class="kw">end</span>
-
+<!-- -->
 <span class="kw">cell</span> <span class="ty">main</span>() -&gt; <span class="ty">String</span> / {<span class="ct">Log</span>}
   <span class="kw">perform</span> <span class="ty">Log</span>.info(<span class="str">"Starting"</span>)
   <span class="kw">return</span> <span class="str">"Done"</span>
 <span class="kw">end</span>
-
+<!-- -->
 <span class="kw">handle</span> main() <span class="kw">with</span> <span class="ty">Log</span>.info(msg) -&gt; resume(unit)
   print(<span class="str">"LOG: {msg}"</span>)
 <span class="kw">end</span></pre>

--- a/src/content/languages/magpie.md
+++ b/src/content/languages/magpie.md
@@ -48,7 +48,7 @@ The distinctive move shows up in the cross-camp comparison with Vera. Vera adds 
 <span class="kw">exports</span> { <span class="sl">@main</span> }
 <span class="kw">imports</span> { }
 <span class="kw">digest</span> <span class="str">"0000000000000000"</span>
-
+<!-- -->
 <span class="kw">fn</span> <span class="sl">@add_two</span>(a: <span class="ty">i64</span>, b: <span class="ty">i64</span>) -&gt; <span class="ty">i64</span> {
 <span class="sl">bb0</span>:
   <span class="sl">%sum</span>: <span class="ty">i64</span> = i.add { lhs=<span class="sl">%a</span>, rhs=<span class="sl">%b</span> }

--- a/src/content/languages/mog.md
+++ b/src/content/languages/mog.md
@@ -56,11 +56,11 @@ The distinctive move is what Mog refuses to do. It is not standalone; it has no 
   <div class="code">
 <pre><span class="kw">import</span> agent;
 <span class="kw">optional</span> log;
-
+<!-- -->
 <span class="cm">// post-compaction hook: re-inject key context</span>
 <span class="kw">pub</span> <span class="kw">fn</span> on_post_compaction(session: agent.<span class="ty">Session</span>) {
   log.info(<span class="str">"post-compaction hook: injecting reminder"</span>);
-
+<!-- -->
   session.messages.push(agent.<span class="ty">Message</span> {
     role: agent.<span class="ty">Role</span>.SYSTEM,
     content: <span class="str">"IMPORTANT: Always run tests before committing."</span>,

--- a/src/content/languages/nanolang.md
+++ b/src/content/languages/nanolang.md
@@ -63,16 +63,16 @@ The distinctive move is the depth of what is actually proved &mdash; and the hon
 <pre><span class="kw">fn</span> <span class="ty">greet</span>(name: <span class="ty">string</span>) -&gt; <span class="ty">string</span> {
   <span class="kw">return</span> (+ <span class="str">"Hello, "</span> name)
 }
-
+<!-- -->
 <span class="kw">shadow</span> greet {
   <span class="ct">assert</span> (== (greet <span class="str">"World"</span>) <span class="str">"Hello, World"</span>)
 }
-
+<!-- -->
 <span class="kw">fn</span> <span class="ty">main</span>() -&gt; <span class="ty">int</span> {
   (<span class="ty">println</span> (greet <span class="str">"World"</span>))
   <span class="kw">return</span> <span class="num">0</span>
 }
-
+<!-- -->
 <span class="kw">shadow</span> main { <span class="ct">assert</span> <span class="kw">true</span> }</pre>
   </div>
   <p class="caption">Every function needs a shadow block. <code>shadow main { assert true }</code> exists only because the compiler refuses to compile without it — and the trivial case still has to satisfy the discipline.</p>

--- a/src/content/languages/nerd.md
+++ b/src/content/languages/nerd.md
@@ -49,7 +49,7 @@ The distinctive move is what NERD does *not* ship: no type system, no error unio
 repeat n times as i
   if i mod 15 eq zero out "FizzBuzz" else if i mod three eq zero out "Fizz" else if i mod five eq zero out "Buzz" else out i
 done
-
+<!-- -->
 fn main
 call fizzbuzz 15</pre>
   </div>

--- a/src/content/languages/pact.md
+++ b/src/content/languages/pact.md
@@ -53,7 +53,7 @@ fn create_user(data: NewUser) -&gt; User or BadRequest
 {
   let existing: User = find_by_email(data.email)
   return BadRequest { message: "Email already taken" } if existing != nothing
-
+<!-- -->
   let user: User = {
     id: rng.uuid(),
     email: data.email,
@@ -61,7 +61,7 @@ fn create_user(data: NewUser) -&gt; User or BadRequest
     active: true,
     created_at: time.now(),
   }
-
+<!-- -->
   db.insert("users", user)
 }</pre>
   </div>

--- a/src/content/languages/plumbing.md
+++ b/src/content/languages/plumbing.md
@@ -47,11 +47,11 @@ The distinctive move is to refuse the orchestration camp's normal framing. Where
   <div class="code">
 <pre><span class="kw">type</span> <span class="ty">Verdict</span> = { verdict: <span class="ty">bool</span>, commentary: <span class="ty">string</span>, draft: <span class="ty">string</span> }
 <span class="kw">type</span> <span class="ty">Review</span>  = { score: <span class="ty">int</span>, review: <span class="ty">string</span>, draft: <span class="ty">string</span> }
-
+<!-- -->
 <span class="kw">let</span> composer : !<span class="ty">string</span>  <span class="op">-&gt;</span> !<span class="ty">string</span>  = <span class="kw">agent</span> { ... }
 <span class="kw">let</span> checker  : !<span class="ty">string</span>  <span class="op">-&gt;</span> !<span class="ty">Verdict</span> = <span class="kw">agent</span> { ... }
 <span class="kw">let</span> critic   : !<span class="ty">Verdict</span> <span class="op">-&gt;</span> !<span class="ty">Review</span>  = <span class="kw">agent</span> { ... }
-
+<!-- -->
 <span class="kw">let</span> main : !<span class="ty">string</span> <span class="op">-&gt;</span> !<span class="ty">string</span> = <span class="kw">plumb</span>(input, output) {
   input   ; composer ; checker
   checker ; <span class="ty">filter</span>(verdict = <span class="kw">false</span>)

--- a/src/content/languages/vow.md
+++ b/src/content/languages/vow.md
@@ -64,7 +64,7 @@ The distinctive move is the choice of checker. Vera and Intent dispatch contract
 <div class="code-sample">
   <div class="code">
 <pre><span class="kw">module</span> <span class="ty">Bisect</span>
-
+<!-- -->
 <span class="kw">fn</span> bisect(lo: <span class="ty">i64</span>, hi: <span class="ty">i64</span>) -&gt; <span class="ty">i64</span> <span class="kw">vow</span> {
   <span class="ct">requires</span>: hi &gt;= lo
 } {
@@ -78,7 +78,7 @@ The distinctive move is the choice of checker. Vera and Intent dispatch contract
   }
   lo
 }
-
+<!-- -->
 <span class="kw">fn</span> main() -&gt; <span class="ty">i32</span> [<span class="ct">io</span>] {
   <span class="kw">let</span> r: <span class="ty">i64</span> = bisect(<span class="num">0</span>, <span class="num">64</span>);
   print_i64(r);


### PR DESCRIPTION
Fixes the 14 entries in #40. Separator lines only; no entry prose changes.

## What was wrong

A blank line inside the `<pre>` ends the surrounding CommonMark type-6 HTML block. Markdown parses what follows as a paragraph and injects `<p>` tags inside the `<pre>`, so the sample loses its indentation and its line breaks. The tokens survive, which is why this went unnoticed: nothing looks escaped, and the sweep fingerprint documented before #41 could not see it.

Axis shows the cost. The `SOURCE` and `REALM` bodies were rendering flush left, which reads as a flat list of unrelated statements rather than two nested blocks:

| before | after |
|---|---|
| <pre>SHAPE Todo<br>  id UUID PK AUTO<br>  title STRING 200 REQUIRED<br>  completed BOOL DEFAULT false<br>SOURCE todos POSTGRES<br>SHAPE Todo<br>INDEX completed<br>REALM api<br>CAPABILITY read todos</pre> | <pre>SHAPE Todo<br>  id UUID PK AUTO<br>  title STRING 200 REQUIRED<br>  completed BOOL DEFAULT false<br><br>SOURCE todos POSTGRES<br>  SHAPE Todo<br>  INDEX completed<br><br>REALM api<br>  CAPABILITY read todos</pre> |

## The fix

25 separator lines across 14 entries become `<!-- -->`, which is not a blank line to the parser and renders as nothing inside a `<pre>`. The technique is @rileyr's, from #21 on the Hale entry, and it beats the language-syntax comment CLAUDE.md used to recommend because it leaves nothing visible in the sample.

The whole diff is 25 removals and 25 additions, every one of them a blank line becoming `<!-- -->`.

| ailang | aver | axis | codong | llmlang | lume | lumen |
|---|---|---|---|---|---|---|
| 2 | 1 | 3 | 1 | 1 | 2 | 2 |

| magpie | mog | nanolang | nerd | pact | plumbing | vow |
|---|---|---|---|---|---|---|
| 1 | 2 | 3 | 1 | 2 | 2 | 2 |

Those counts match the injected `<p>` count measured on each page before the change, one for one.

## Verification

- The sweep documented in CLAUDE.md now returns `intent`, `plasm` and `tacit` and nothing else. Those three are the fence-based class in #5, a different cause.
- Each of the 14 pages independently confirmed clean of all three fingerprints.
- `<!-- -->` is invisible to a reader: it is an HTML comment, and the visible text of each `<pre>` contains no trace of it.

One consequence worth naming: the markdown companions and `llms-full.txt` carry the raw body, so `<!-- -->` appears there as literal markup. Those surfaces already carry raw `<div>`, `<pre>` and `<span>` markup, and Hale has shipped this way since #21, so this is consistent rather than new. The alternative, a comment in each language's own syntax, would put a visible comment in both the page and the companion.

`nerd` was worth doing regardless of the rest: it is the syntactic camp's homepage anchor, so its detail page is one of three the homepage sends readers to.

Closes #40
