### PR TITLE
Hand-tune the Tacit, Intent and Plasm code samples

### DIFF
--- a/src/content/languages/intent.md
+++ b/src/content/languages/intent.md
@@ -53,27 +53,30 @@ The distinctive move is the **intent block** itself: a named natural-language go
 
 ## What it looks like.
 
-```intent
-entity BankAccount {
-    field balance: Int;
-
-    invariant self.balance >= 0;
-
-    method deposit(amount: Int) returns Void
-        requires amount > 0
-        ensures self.balance == old(self.balance) + amount
+<div class="code-sample">
+  <div class="code">
+<pre><span class="kw">entity</span> <span class="ty">BankAccount</span> {
+    <span class="kw">field</span> balance: <span class="ty">Int</span>;
+<!-- -->
+    <span class="ct">invariant</span> <span class="kw">self</span>.balance <span class="op">&gt;=</span> <span class="num">0</span>;
+<!-- -->
+    <span class="kw">method</span> deposit(amount: <span class="ty">Int</span>) <span class="kw">returns</span> <span class="ty">Void</span>
+        <span class="ct">requires</span> amount <span class="op">&gt;</span> <span class="num">0</span>
+        <span class="ct">ensures</span> <span class="kw">self</span>.balance <span class="op">==</span> <span class="kw">old</span>(<span class="kw">self</span>.balance) <span class="op">+</span> amount
     {
-        self.balance = self.balance + amount;
+        <span class="kw">self</span>.balance <span class="op">=</span> <span class="kw">self</span>.balance <span class="op">+</span> amount;
     }
 }
-
-intent "Safe withdrawal preserves non-negative balance" {
-    goal "BankAccount.withdraw never results in balance < 0";
-    guarantee "if withdraw returns false then balance is unchanged";
-    verified_by BankAccount.invariant;
-    verified_by BankAccount.withdraw.requires;
-}
-```
+<!-- -->
+<span class="kw">intent</span> <span class="str">"Safe withdrawal preserves non-negative balance"</span> {
+    <span class="ct">goal</span> <span class="str">"BankAccount.withdraw never results in balance &lt; 0"</span>;
+    <span class="ct">guarantee</span> <span class="str">"if withdraw returns false then balance is unchanged"</span>;
+    <span class="ct">verified_by</span> <span class="ty">BankAccount</span>.invariant;
+    <span class="ct">verified_by</span> <span class="ty">BankAccount</span>.withdraw.requires;
+}</pre>
+  </div>
+  <p class="caption">An entity whose invariant and method contracts are machine-checkable, then an intent block naming the clauses that discharge a natural-language goal.</p>
+</div>
 
 `old(...)` captures pre-mutation state for `ensures` clauses. `forall i in 0..n: p` and `exists i in 0..n: p` quantify over integer ranges in contracts. Loops carry `invariant` and `decreases` clauses for inductive reasoning at verification time.
 

--- a/src/content/languages/nerd.md
+++ b/src/content/languages/nerd.md
@@ -53,7 +53,7 @@ done
 fn main
 call fizzbuzz 15</pre>
   </div>
-  <p class="caption">Every operator is a word: <code>mod</code>, <code>eq</code>, <code>repeat</code>, <code>done</code>. No braces, no semicolons, no <code>+</code>/<code>==</code>.</p>
+  <p class="caption">Every operator is a word: <code>mod</code>, <code>eq</code>, <code>repeat</code>, <code>done</code>. No braces, no semicolons, no <code>+</code>/<code>==</code>. Statements are delimited by line rather than by punctuation, so a conditional chain has nowhere to break: the <code>if</code> above runs to 124 characters and scrolls sideways. This sample is <code>examples/fizzbuzz.nerd</code> from the repository, unaltered.</p>
 </div>
 
 ## Distinctive moves.

--- a/src/content/languages/plasm.md
+++ b/src/content/languages/plasm.md
@@ -48,16 +48,19 @@ Plasm treats the agent integration problem as a **language and plan** problem, n
 
 ## What it looks like.
 
-```text
-issues = e1{p46="open"}.page_size(50)
-labels = issues.r3
-report = labels[p50] <<RPT
-{% for r in rows %}{{ r.p50 }}
-{% endfor %}
-RPT
-sent = e1.m13(p91=report.content)
-issues, sent
-```
+<div class="code-sample">
+  <div class="code">
+<pre>issues <span class="op">=</span> <span class="sl">e1</span>{<span class="sl">p46</span><span class="op">=</span><span class="str">"open"</span>}.page_size(<span class="num">50</span>)
+labels <span class="op">=</span> issues.<span class="sl">r3</span>
+report <span class="op">=</span> labels[<span class="sl">p50</span>] <span class="kw">&lt;&lt;RPT</span>
+<span class="ct">{% for r in rows %}</span><span class="sl">{{ r.p50 }}</span>
+<span class="ct">{% endfor %}</span>
+<span class="kw">RPT</span>
+sent <span class="op">=</span> <span class="sl">e1</span>.<span class="sl">m13</span>(<span class="sl">p91</span><span class="op">=</span>report.content)
+issues, sent</pre>
+  </div>
+  <p class="caption">Filter issues, hop a relation, render a template into a heredoc, then post the result. Every <code>e#</code>, <code>p#</code>, <code>r#</code> and <code>m#</code> is a session-local symbol copied from the teaching table.</p>
+</div>
 
 Symbols are **session-local**: `e1` might mean GitHub `Issue` in one federated session and Linear `Issue` as `e2` when both catalogs are seeded. The grammar rules are stable; the vocabulary is **catalog-parameterised** (like SQL over a schema). Canonical surface spec: [Plasm language definition](https://plasmtools.github.io/plasm-core/reference/plasm-language-definition/).
 

--- a/src/content/languages/tacit.md
+++ b/src/content/languages/tacit.md
@@ -51,18 +51,21 @@ Two views render the same tree: a dense **authoring view** sized for model token
 
 ## What it looks like.
 
-```tacit
-unit Math {
-  import inc : Int -> Int
-    from blake3:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef;
-
-  private double : Int -> Int =
-    lambda x. @add x x;
-
-  export public add_two : Int -> Int =
-    lambda x. inc (inc x);
-}
-```
+<div class="code-sample">
+  <div class="code">
+<pre><span class="kw">unit</span> Math {
+  <span class="kw">import</span> inc : <span class="ty">Int</span> -&gt; <span class="ty">Int</span>
+    <span class="kw">from</span> blake3:<span class="num">0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef</span>;
+<!-- -->
+  <span class="kw">private</span> double : <span class="ty">Int</span> -&gt; <span class="ty">Int</span> =
+    <span class="kw">lambda</span> x<span class="op">.</span> <span class="sl">@add</span> x x;
+<!-- -->
+  <span class="kw">export</span> <span class="kw">public</span> add_two : <span class="ty">Int</span> -&gt; <span class="ty">Int</span> =
+    <span class="kw">lambda</span> x<span class="op">.</span> inc (inc x);
+}</pre>
+  </div>
+  <p class="caption">One unit: an import pinned to a definition hash, a private binding, and an exported one. <code>@add</code> is a builtin; <code>lambda x.</code> binds by position.</p>
+</div>
 
 Imports name exact `blake3:<64-hex>` definition hashes, not paths or version ranges. Visibility (`public` / `package` / `private`) is part of the artefact. The display names `x`, `inc`, `double` are sidecar metadata; in canonical form references are DeBruijn indices.
 


### PR DESCRIPTION
Closes #5, and finishes the pair with #40. The catalogue-wide sweep in CLAUDE.md now returns nothing.

## What was wrong

`tacit`, `intent` and `plasm` shipped as markdown fences (```` ```tacit ````, ```` ```intent ````, ```` ```text ````). Shiki knows none of the three languages, so the fallback was undifferentiated monospace: no keyword colour, no contract colour, no styled container, no caption. Every other entry with a sample uses the hand-tuned pattern.

This is a different cause from #40, which is why the two were tracked separately. #40 was a parser break in samples that already used the pattern; these three never adopted it.

## The code is unchanged

The rendered text of all three samples is byte-identical to what the fences contained, verified line by line, blank lines included. Those blank lines are now `<!-- -->` separators, so the samples cannot reacquire the bug #46 just fixed.

## Token choices

Worth recording, because these were judgement calls rather than mechanical:

- **Tacit.** `@add` is a builtin reference, so `sl`. The `blake3:` digest is a literal, so `num`, following the suggestion in this issue.
- **Intent.** `kw` and `ct` are kept apart so `requires`, `ensures`, `invariant`, `goal`, `guarantee` and `verified_by` carry the contract colour rather than the keyword colour. For a verification-camp language whose distinctive move is that `verified_by` must resolve to a real clause, that distinction is the sample's whole point.
- **Plasm.** `e#`, `m#`, `p#` and `r#` are session-local opaque symbols an agent copies from a teaching table, which is exactly what `sl` means. The Jinja control directives are `ct`; the interpolation is `sl`.

## The NERD caption

Rolled in here rather than as a separate PR. Its sample is `examples/fizzbuzz.nerd` verbatim, and the language delimits statements by line with no braces or semicolons, so a conditional chain has nowhere to break and runs to 124 characters. Measured at a 1280px viewport it is the only sample in the catalogue that overflows its container, by 60px, and `overflow-x: auto` means it scrolls rather than clipping. The caption now explains that instead of leaving a reader to assume the sample is mangled.

## Verification

- Rendered text of each converted sample compared line by line against the original fence content: identical for all three.
- Every token class used resolves to a colour in `global.css`; computed colours confirmed in the browser (`kw` orange, `ct` amber, `ty` green, `str` cream, `op` pale, `sl`, `num`).
- At a 1280px viewport, all three converted samples have zero horizontal overflow. NERD is the only page in the catalogue with any.
- The sweep documented in CLAUDE.md returns nothing across all 40 entries.
