### PR TITLE
docs: the deploy does not use a gh-pages branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,10 @@ CC BY 4.0 for content.
 - **Star counts:** Baked in at build time from `src/data/stars.json`,
   refreshed weekly by `.github/workflows/refresh-stars.yml`. **No** live
   GitHub API calls from the site.
-- **Deploy:** GitHub Pages, served from the `gh-pages` branch. The
+- **Deploy:** GitHub Pages, built and published by Actions rather than served
+  from a branch. Pages is set to `build_type: workflow`, so `dist/` is uploaded
+  as an artifact and deployed straight from the run; there is no `gh-pages`
+  branch, and `main` is the only branch the repository carries. The
   `.github/workflows/deploy.yml` workflow runs on every push to `main` and
   also via `workflow_run` after the stars refresh completes (so weekly
   refreshes propagate without a separate human-driven deploy).


### PR DESCRIPTION
CLAUDE.md described the deploy as "GitHub Pages, served from the `gh-pages` branch". There is no such branch on the repository, and there never has been.

Pages is configured with `build_type: workflow`. `deploy.yml` uploads `dist/` through `actions/upload-pages-artifact` and publishes it with `actions/deploy-pages`, directly from the run. No branch is involved at any point.

```
$ gh api repos/aallan/agentlanguages/pages --jq .build_type
workflow

$ gh api repos/aallan/agentlanguages/branches --jq '.[].name'
main
```

This surfaced while pruning merged branches. Once the ten stale ones were gone the list was `main` and nothing else, which is what prompted checking the claim rather than reading past it.

The correction matters for more than tidiness: anyone acting on the old sentence would go looking for a branch to inspect or fix a deploy from, and there is nothing there to find.
