### PR TITLE
Fail the build on a crossref slug that names no entry

### DIFF
--- a/src/lib/validate-crossrefs.ts
+++ b/src/lib/validate-crossrefs.ts
@@ -1,0 +1,81 @@
+import type { CollectionEntry } from 'astro:content';
+
+/**
+ * Fail the build if any `crossrefs[].slug` does not name a real entry.
+ *
+ * The Zod schema in `src/content.config.ts` validates `crossrefs[].camp`
+ * against `campEnum` but leaves `slug` a bare string, because a schema has no
+ * clean way to see its sibling entries while they are still loading. An
+ * unchecked slug is not a build error, it is a dead link on a rendered detail
+ * page, which is the kind of fault that survives review: crossrefs arrive
+ * hand-written in contributor PRs, and CONTRIBUTING asks for two to four of
+ * them per entry.
+ *
+ * Called from `getStaticPaths` in `src/pages/languages/[slug].astro`, which
+ * receives the whole collection before it filters to entries with a body, so
+ * bodyless entries are covered too.
+ */
+
+/** Levenshtein distance, for the "did you mean" hint. */
+function distance(a: string, b: string): number {
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    for (let j = 1; j <= b.length; j++) {
+      row[j] = Math.min(
+        prev[j] + 1,
+        row[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      );
+    }
+    prev = row;
+  }
+  return prev[b.length];
+}
+
+/** The closest real slug, when one is close enough to be worth suggesting. */
+function nearest(slug: string, known: string[]): string | null {
+  let best: string | null = null;
+  let bestDistance = Infinity;
+  for (const candidate of known) {
+    const d = distance(slug, candidate);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = candidate;
+    }
+  }
+  // Two edits on a short slug is still plausibly a typo; beyond that the
+  // suggestion is noise and the author meant something we do not have.
+  return best !== null && bestDistance <= Math.max(2, Math.floor(slug.length / 3))
+    ? best
+    : null;
+}
+
+export function validateCrossrefs(languages: CollectionEntry<'languages'>[]): void {
+  const known = languages.map((l) => l.id).sort();
+  const ids = new Set(known);
+
+  const broken: string[] = [];
+  for (const entry of languages) {
+    for (const ref of entry.data.crossrefs ?? []) {
+      if (ids.has(ref.slug)) continue;
+      const hint = nearest(ref.slug, known);
+      broken.push(
+        `  ${entry.id}.md -> crossref slug "${ref.slug}" (named "${ref.name}") matches no entry` +
+          (hint ? `; did you mean "${hint}"?` : '')
+      );
+    }
+  }
+
+  if (broken.length > 0) {
+    const summary =
+      broken.length === 1
+        ? '1 crossref points at an entry that does not exist'
+        : `${broken.length} crossrefs point at entries that do not exist`;
+    throw new Error(
+      `${summary}:\n` +
+        `${broken.join('\n')}\n\n` +
+        `Every crossrefs[].slug must match a filename in src/content/languages/ without its .md extension.`
+    );
+  }
+}

--- a/src/pages/languages/[slug].astro
+++ b/src/pages/languages/[slug].astro
@@ -2,9 +2,13 @@
 import { getCollection, render } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import Base from '../../layouts/Base.astro';
+import { validateCrossrefs } from '../../lib/validate-crossrefs';
 
 export async function getStaticPaths() {
   const languages = await getCollection('languages');
+  // Fails the build on a crossref slug that names no entry. Runs here because
+  // this is where the whole collection is in hand, before the body filter.
+  validateCrossrefs(languages);
   // Only generate detail pages for entries with a non-empty body.
   return languages
     .filter((l) => (l.body ?? '').trim().length > 0)


### PR DESCRIPTION
Closes #16.

`crossrefs[].slug` was a bare `z.string()` while `camp` beside it was validated against `campEnum`, so the inconsistency was visible in the schema itself. An unchecked slug never failed anything; it produced a dead link on a rendered detail page, which is the kind of fault that survives review.

## Where the check lives

The schema cannot do this cleanly, since it has no dependable way to read sibling entries while they are still loading. `getStaticPaths` in `languages/[slug].astro` already has the whole collection, and has it **before** the filter that drops bodyless entries, so the check covers all 41 entries rather than only the ones that render a page. That is option 2 from the issue.

## What a failure looks like

Every miss is reported at once rather than the first, and a near miss gets the closest real slug suggested, because a typo is the actual failure mode:

```
2 crossrefs point at entries that do not exist:
  reqlan.md -> crossref slug "verra" (named "Vera") matches no entry; did you mean "vera"?
  vera.md -> crossref slug "zzzzquux" (named "Tacit") matches no entry

Every crossrefs[].slug must match a filename in src/content/languages/ without its .md extension.
```

The suggestion is suppressed when nothing is close enough, as on the second line, so it never invents a confident wrong answer.

## Verification

Tested by injecting faults rather than by reasoning about the code:

| case | result |
|---|---|
| real catalogue, 125 crossrefs | builds, exit 0, 42 pages |
| one near-miss slug | exit 1, singular message, correct suggestion |
| one near miss and one far-off slug | exit 1, plural message, both listed, suggestion only on the near miss |

All 125 crossrefs currently resolve, so this is prevention rather than a fix. It earns its place because crossrefs arrive hand-written in contributor PRs and CONTRIBUTING asks for two to four per entry: the count went from 113 to 125 in the last three weeks alone.

`src/lib/` is new. A build-time validator is not page, layout or data, and `lib` is the conventional Astro home for it.
