### PR TITLE
Add a code sample to the Boruna entry

### DIFF
--- a/src/content/languages/boruna.md
+++ b/src/content/languages/boruna.md
@@ -59,6 +59,28 @@ Boruna doesn't think the problem with LLM code is the code. It thinks the proble
 
 The unit of computation is a DAG workflow. Each step is an `.ax` source file. Every side effect — LLM call, HTTP request, database write, filesystem mutation — is declared in the source and policy-gated at the VM level. The VM refuses to execute a step that would perform an undeclared effect; the policy layer lets administrators forbid specific declared effects per workflow or per role. Every executed step writes to a hash-chained evidence bundle that's tamper-evident; the bundle is sufficient to replay the workflow deterministically (same inputs, same model responses recorded, same outputs).
 
+## What it looks like.
+
+<div class="code-sample">
+  <div class="code">
+<pre><span class="cm">// Capability demo — functions declare their side effects</span>
+<!-- -->
+<span class="kw">fn</span> get_time() -&gt; <span class="ty">Int</span> <span class="ct">!{time}</span> {
+    <span class="num">42</span>
+}
+<!-- -->
+<span class="kw">fn</span> pure_add(a: <span class="ty">Int</span>, b: <span class="ty">Int</span>) -&gt; <span class="ty">Int</span> {
+    a <span class="op">+</span> b
+}
+<!-- -->
+<span class="kw">fn</span> main() -&gt; <span class="ty">Int</span> {
+    <span class="kw">let</span> t: <span class="ty">Int</span> = get_time()
+    pure_add(t, <span class="num">10</span>)
+}</pre>
+  </div>
+  <p class="caption"><code>examples/capabilities.ax</code>, unaltered. The <code>!{time}</code> clause is the declaration the VM enforces: <code>get_time</code> may read the clock, <code>pure_add</code> may not, and a step that reaches for an effect missing from its own signature does not run. Effects reach the VM as values rather than as calls, which is what lets each one be recorded in the evidence bundle and replayed from it.</p>
+</div>
+
 ## Distinctive moves.
 
 - **Capability-safe by construction.** A step can't reach for an effect it didn't declare. The VM is the enforcement point, not a linter.


### PR DESCRIPTION
Closes #18. All three homepage anchors now show the language they anchor.

## Why this one mattered

Boruna anchors the orchestration camp on the homepage, and its detail page never showed a line of `.ax`. A reader who had just read the camp's thesis arrived at a page describing the design under an anchor quote promising "When a regulator asks what exactly ran, you can prove it", with nothing to look at. It was also the shortest of the three anchors, at 462 words against NERD's 559 and Vera's 1210.

## What the sample shows

`examples/capabilities.ax` from the repository, **unaltered**, verified byte for byte against the source:

```
// Capability demo — functions declare their side effects

fn get_time() -> Int !{time} {
    42
}

fn pure_add(a: Int, b: Int) -> Int {
    a + b
}

fn main() -> Int {
    let t: Int = get_time()
    pure_add(t, 10)
}
```

The issue offered three candidates: a policy-gated effect declaration, a workflow step with its approval gate, or whatever produces the evidence bundle. I went with the first, because the entry's own first distinctive move is that "a step can't reach for an effect it didn't declare", and this file is the project's designated demonstration of precisely that. `get_time` carries `!{time}`; `pure_add` carries nothing; the VM refuses a step performing an effect absent from its signature.

The evidence-bundle option turned out not to be language syntax at all. Bundles are produced by the runtime, and the compliance workflow definitions are JSON with empty `capabilities` arrays, so they would have illustrated less while looking like more.

`!{time}` is styled `ct` rather than `kw`, so the declaration is the token that stands out. That is the whole reason for showing the snippet.

## Verification

- Rendered text compared line by line against `examples/capabilities.ax`: identical.
- All three sweep fingerprints clean; the catalogue-wide sweep reports nothing.
- Longest line is 57 characters, so no horizontal overflow.
- Blank lines use the `<!-- -->` separator, so the sample does not arrive carrying the bug fixed in #46.

Twelve entries still have no sample. None of them is an anchor, and the issue notes that gap is lower priority.
