### PR TITLE
Add Schema.org JSON-LD to detail pages and the homepage

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -7,12 +7,15 @@ interface Props {
   title: string;
   description?: string;
   campAccent?: 'syntactic' | 'verification' | 'orchestration' | 'adjacent' | 'unclassified';
+  /** Schema.org JSON-LD for this page. Emitted verbatim in <head>. */
+  jsonLd?: Record<string, unknown>;
 }
 
 const {
   title,
   description = 'A community-edited catalogue of programming languages designed for AI agents to author code.',
   campAccent,
+  jsonLd,
 } = Astro.props;
 
 const bodyStyle = campAccent ? `--camp: var(--camp-${campAccent});` : undefined;
@@ -67,6 +70,12 @@ if (pathname === '/' || pathname === '') {
     <link rel="alternate" type="text/markdown" href="/llms-full.txt" title="llms-full.txt — full catalogue text" />
     <link rel="llms-txt" href="/llms.txt" />
     <link rel="llms-full-txt" href="/llms-full.txt" />
+    {/* Schema.org structured data, for crawlers and agent SDKs that read
+        JSON-LD rather than the markdown companions above. Built per page and
+        passed in, so each route decides its own @type. */}
+    {jsonLd && (
+      <script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} />
+    )}
     <meta name="generator" content={Astro.generator} />
 
     <meta property="og:title" content={title} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,8 +43,41 @@ const buildDate = new Date();
 const asOfLabel = `${buildDate.getDate()} ${monthNames[buildDate.getMonth()]} ${buildDate.getFullYear()}`;
 
 const trackedCount = languages.length;
+
+// Schema.org JSON-LD. The homepage is a CollectionPage over the catalogue,
+// which is what lets a crawler read the site as a structured directory rather
+// than as one long article. Only entries that render a detail page are listed,
+// so every itemListElement has somewhere to point.
+const listed = languages.filter((l) => (l.body ?? '').trim().length > 0);
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'agentlanguages.dev',
+  description:
+    'A community-edited catalogue of programming languages designed for AI agents to author code, organised around three philosophical camps: syntactic, verification, and orchestration.',
+  url: 'https://agentlanguages.dev/',
+  inLanguage: 'en',
+  isPartOf: { '@type': 'WebSite', name: 'agentlanguages.dev', url: 'https://agentlanguages.dev' },
+  mainEntity: {
+    '@type': 'ItemList',
+    name: 'Programming languages designed for AI agents to write',
+    numberOfItems: listed.length,
+    itemListElement: listed.map((l, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `https://agentlanguages.dev/languages/${l.id}/`,
+      item: {
+        '@type': 'SoftwareSourceCode',
+        name: l.data.name,
+        description: l.data.one_liner,
+        url: l.data.url,
+      },
+    })),
+  },
+};
 ---
 <Base
+  jsonLd={jsonLd}
   title="agentlanguages.dev — Programming languages designed for AI agents to write"
   description="A community-edited catalogue of programming languages designed for AI agents to author code, organised around three philosophical camps: syntactic, verification, and orchestration."
 >

--- a/src/pages/languages/[slug].astro
+++ b/src/pages/languages/[slug].astro
@@ -77,11 +77,46 @@ const next = detailIdx >= 0 && detailIdx < withDetail.length - 1 ? withDetail[de
 const siteHost = (() => {
   try { return new URL(data.url).hostname; } catch { return data.url; }
 })();
+
+// Schema.org JSON-LD. The page is an Article about a piece of software, so
+// the editorial framing is the Article and the language sits under `about`.
+//
+// No `datePublished`: we do not record when an entry was added, and
+// `date_appeared` is when the *language* appeared, which is a different fact.
+// It belongs on the software instead, as `dateCreated`.
+//
+// `about.author` is deliberately absent. Schema.org types `author` as
+// Person or Organization, and the frontmatter field is free text covering
+// both ("escapeboy", "Chris Tate and Matt Van Horn / Vercel Labs"), so there
+// is no way to classify it correctly at build time. It stays visible in the
+// page and the markdown companion rather than being emitted mistyped here.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: `${data.name} — agentlanguages.dev`,
+  description: data.one_liner,
+  url: new URL(Astro.url.pathname, Astro.site).toString(),
+  inLanguage: 'en',
+  author: { '@type': 'Organization', name: 'agentlanguages.dev', url: 'https://agentlanguages.dev' },
+  publisher: { '@type': 'Organization', name: 'agentlanguages.dev', url: 'https://agentlanguages.dev' },
+  isPartOf: { '@type': 'CollectionPage', name: 'agentlanguages.dev', url: 'https://agentlanguages.dev' },
+  about: {
+    '@type': 'SoftwareSourceCode',
+    name: data.name,
+    description: data.one_liner,
+    url: data.url,
+    ...(data.repo ? { codeRepository: `https://github.com/${data.repo}` } : {}),
+    ...(data.implementation_language ? { programmingLanguage: data.implementation_language } : {}),
+    ...(data.license ? { license: data.license } : {}),
+    ...(data.date_appeared ? { dateCreated: data.date_appeared } : {}),
+  },
+};
 ---
 <Base
   title={`${data.name} — agentlanguages.dev`}
   description={data.one_liner}
   campAccent={data.camp}
+  jsonLd={jsonLd}
 >
   <div class="col col-full">
     <div class="breadcrumb">


### PR DESCRIPTION
Closes #3.

`Base.astro` takes an optional `jsonLd` prop and emits it in `<head>`, so each route picks its own `@type`. Detail pages are an `Article` whose `about` is the `SoftwareSourceCode`; the homepage is a `CollectionPage` whose `mainEntity` is an `ItemList` of the 41 entries that render a detail page.

## Two fields deliberately left out

Both would have stated something we do not know, which is the opposite of what structured data is for.

**`datePublished` on the Article.** The sketch in the issue set it to `${data.date_appeared}-01`. That is when the *language* appeared, not when the catalogue entry was published, and Schema.org reads `datePublished` as the latter. We do not record when an entry was added, so the honest move is to omit it and put the fact where it belongs: `about.dateCreated`.

**`about.author`.** Schema.org types `author` as `Person` or `Organization`. The frontmatter field is free text spanning both, from `escapeboy` to `Chris Tate and Matt Van Horn / Vercel Labs`, and nothing at build time can classify which. Emitting it as a bare string would be invalid, and guessing `Person` would be wrong for a third of the catalogue. It stays visible in the page and the markdown companion instead.

## The homepage half

The issue raised this as an open question. I did it, because a site whose whole pitch is machine-readability leaving its front door unstructured seemed the odder choice, and it is the same mechanism. **Easy to drop** if you would rather not: it is the `jsonLd` block in `index.astro` and one prop on the `<Base>` call.

## Verification

- **42 blocks emitted**, one per detail page plus the homepage.
- **Every one parses as raw JSON with no unescaping**, which is what a browser actually does. My first pass validated them through `html.unescape`, which would have hidden an escaping fault, so I re-ran it without.
- The two redirect stubs under `/languages/raskell` get no block. That is correct: they are `noindex` refresh stubs pointing at `bhc-hx`.
- All 41 `itemListElement` URLs resolve to built pages, and positions run 1..41 contiguously.
- No entry's frontmatter contains `</script>`, `<!--` or `]]>`, so nothing can break out of the script tag; checked rather than assumed.
- No HTML entities leak into any `description`.
